### PR TITLE
Update gsw_geo_strf_dyn_height.f90

### DIFF
--- a/toolbox/gsw_geo_strf_dyn_height.f90
+++ b/toolbox/gsw_geo_strf_dyn_height.f90
@@ -274,7 +274,7 @@ contains
     ! Generate the sequence ensuring that the value of p2 is exact to
     ! avoid round-off issues, ie. don't do "pseq = (p1+pstep*i, i=1,n)".
 
-    pseq = (/ (p2-pstep*i, i=n-1,0,-1) /)
+    pseq(1:n) = (/ (p2-pstep*i, i=n-1,0,-1) /)
 
     return
     end subroutine p_sequence


### PR DESCRIPTION
Test fail with Intel Fortran compiler.
`pseq` array size is not known to the compiler; stating `pseq(1:n)` allows the compiler to allocate appropriate size.
This fix was suggested by @hylandg in response to issue #13
All tests passed with GNU Fortran and Intel Fortran.