### PR TITLE
make gsw_mod_check_data.f90 conform with latest

### DIFF
--- a/.github/workflows/gsw.yml
+++ b/.github/workflows/gsw.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install compiler
         run: |
            sudo apt-get update
-           sudo apt-get install gfortran-${{ matrix.version }}
+           sudo apt-get install gfortran-${{ matrix.version }} cmake
       - name: Clone gsw
         uses: actions/checkout@v2
-      - name: Build and run all test cases
-#        run: python3 cases/scripts/run_all.py --show_logs --gotm_base=gotm --exclude plume --compiler=gfortran-${{ matrix.version }} -DGOTM_USE_STIM=ON -DGOTM_USE_SEAGRASS=ON -DGOTM_USE_NetCDF=OFF ${{ matrix.cmake_args }}
+      - name: Build
+        run: cmake . -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.version }}

--- a/.github/workflows/gsw.yml
+++ b/.github/workflows/gsw.yml
@@ -1,0 +1,24 @@
+name: Build and test
+on: push
+jobs:
+   gfortran:
+      strategy:
+         matrix:
+            version: [9, 10, 11, 12]
+            os: [ubuntu-latest]
+#            include:
+#               - version: 6
+#                 os: ubuntu-18.04
+#               - version: 8
+#                 cmake_args: -DFABM_USE_CONTIGUOUS=OFF
+         fail-fast: false
+      runs-on: ${{ matrix.os }}
+      steps:
+      - name: Install compiler
+        run: |
+           sudo apt-get update
+           sudo apt-get install gfortran-${{ matrix.version }}
+      - name: Clone gsw
+        uses: actions/checkout@v2
+      - name: Build and run all test cases
+#        run: python3 cases/scripts/run_all.py --show_logs --gotm_base=gotm --exclude plume --compiler=gfortran-${{ matrix.version }} -DGOTM_USE_STIM=ON -DGOTM_USE_SEAGRASS=ON -DGOTM_USE_NetCDF=OFF ${{ matrix.cmake_args }}

--- a/.github/workflows/gsw.yml
+++ b/.github/workflows/gsw.yml
@@ -4,7 +4,7 @@ jobs:
    gfortran:
       strategy:
          matrix:
-            version: [9, 10, 11, 12]
+            version: [9, 10, 11 ] # , 12]
             os: [ubuntu-latest]
 #            include:
 #               - version: 6
@@ -21,4 +21,4 @@ jobs:
       - name: Clone gsw
         uses: actions/checkout@v2
       - name: Build
-        run: cmake . -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.version }}
+        run: mkdir build && cmake . -B build -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.version }} && cmake --build build --target gsw_check_functions.x --target gsw_poly_check.x && ./build/test/gsw_check_functions.x && ./build/test/gsw_poly_check.x

--- a/.github/workflows/gsw.yml
+++ b/.github/workflows/gsw.yml
@@ -6,11 +6,6 @@ jobs:
          matrix:
             version: [9, 10, 11 ] # , 12]
             os: [ubuntu-latest]
-#            include:
-#               - version: 6
-#                 os: ubuntu-18.04
-#               - version: 8
-#                 cmake_args: -DFABM_USE_CONTIGUOUS=OFF
          fail-fast: false
       runs-on: ${{ matrix.os }}
       steps:
@@ -20,5 +15,5 @@ jobs:
            sudo apt-get install gfortran-${{ matrix.version }} cmake
       - name: Clone gsw
         uses: actions/checkout@v2
-      - name: Build
+      - name: Build and run
         run: mkdir build && cmake . -B build -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.version }} && cmake --build build --target gsw_check_functions.x --target gsw_poly_check.x && ./build/test/gsw_check_functions.x && ./build/test/gsw_poly_check.x

--- a/modules/gsw_mod_check_data.f90
+++ b/modules/gsw_mod_check_data.f90
@@ -777,8 +777,10 @@ data pref / &
 
 type(gsw_result) :: c_from_sp
 
-data c_from_sp / gsw_result( &
-  "C_from_SP", 6.1638e-10_r8, (/ &
+data c_from_sp%variable_name, &
+     c_from_sp%computation_accuracy, &
+     c_from_sp%values / &
+  "C_from_SP", 6.1638e-10_r8, &
   55.253405515471_r8, 55.25794746084_r8, 55.205775404914_r8, &
   55.221954702814_r8, 55.198738463981_r8, 55.120885611218_r8, &
   54.545560654633_r8, 53.376252431127_r8, 51.409509650121_r8, &
@@ -815,12 +817,14 @@ data c_from_sp / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sp_from_c
 
-data sp_from_c / gsw_result( &
-  "SP_from_C", 1.2971e-10_r8, (/ &
+data sp_from_c%variable_name, &
+     sp_from_c%computation_accuracy, &
+     sp_from_c%values / &
+  "SP_from_C", 1.2971e-10_r8, &
   34.345367_r8, 34.344894_r8, 34.339741_r8, 34.342312_r8, 34.368393_r8, &
   34.375198_r8, 34.572834_r8, 34.8246_r8, 34.955181_r8, 34.953842_r8, &
   34.821655_r8, 34.670124_r8, 34.442738_r8, 34.430153_r8, 34.455452_r8, &
@@ -845,12 +849,14 @@ data sp_from_c / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sp_from_sk
 
-data sp_from_sk / gsw_result( &
-  "SP_from_SK", 1.2982e-10_r8, (/ &
+data sp_from_sk%variable_name, &
+     sp_from_sk%computation_accuracy, &
+     sp_from_sk%values / &
+  "SP_from_SK", 1.2982e-10_r8, &
   34.344834489668_r8, 34.34436108349_r8, 34.339203658476_r8, &
   34.34177686626_r8, 34.367880262687_r8, 34.374691106316_r8, &
   34.57249682144_r8, 34.824479019391_r8, 34.955172152659_r8, &
@@ -889,12 +895,14 @@ data sp_from_sk / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_from_sp
 
-data sa_from_sp / gsw_result( &
-  "SA_from_SP", 1.3001e-10_r8, (/ &
+data sa_from_sp%variable_name, &
+     sa_from_sp%computation_accuracy, &
+     sa_from_sp%values / &
+  "SA_from_SP", 1.3001e-10_r8, &
   34.507499465692_r8, 34.507024988454_r8, 34.501848858511_r8, &
   34.504435326018_r8, 34.530643613166_r8, 34.537484086977_r8, &
   34.736078147786_r8, 34.98909028723_r8, 35.120394623393_r8, &
@@ -932,12 +940,14 @@ data sa_from_sp / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sstar_from_sp
 
-data sstar_from_sp / gsw_result( &
-  "Sstar_from_SP", 1.3e-10_r8, (/ &
+data sstar_from_sp%variable_name, &
+     sstar_from_sp%computation_accuracy, &
+     sstar_from_sp%values / &
+  "Sstar_from_SP", 1.3e-10_r8, &
   34.507257355553_r8, 34.506781861549_r8, 34.501604153914_r8, &
   34.504186106832_r8, 34.530388583505_r8, 34.537224487135_r8, &
   34.735783282747_r8, 34.988715833138_r8, 35.119874921742_r8, &
@@ -976,12 +986,14 @@ data sstar_from_sp / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_from_t
 
-data ct_from_t / gsw_result( &
-  "CT_from_t", 6.2611e-10_r8, (/ &
+data ct_from_t%variable_name, &
+     ct_from_t%computation_accuracy, &
+     ct_from_t%values / &
+  "CT_from_t", 6.2611e-10_r8, &
   27.994827331979_r8, 27.993492458241_r8, 27.944213680466_r8, &
   27.949774879518_r8, 27.884179948892_r8, 27.793319825682_r8, &
   26.947346080828_r8, 25.46430727652_r8, 23.379820676679_r8, &
@@ -1020,12 +1032,14 @@ data ct_from_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: deltasa_from_sp
 
-data deltasa_from_sp / gsw_result( &
-  "deltaSA_from_SP", 6.9633e-13_r8, (/ &
+data deltasa_from_sp%variable_name, &
+     deltasa_from_sp%computation_accuracy, &
+     deltasa_from_sp%values / &
+  "deltaSA_from_SP", 6.9633e-13_r8, &
   0.00017934084403493_r8, 0.00018009400411501_r8, 0.00018126266425611_r8, &
   0.00018460680456656_r8, 0.00018891085993289_r8, 0.00019229617962679_r8, &
   0.00021841854688631_r8, 0.00027737340189304_r8, 0.00038496418591905_r8, &
@@ -1064,12 +1078,14 @@ data deltasa_from_sp / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sr_from_sp
 
-data sr_from_sp / gsw_result( &
-  "SR_from_SP", 1.3032e-10_r8, (/ &
+data sr_from_sp%variable_name, &
+     sr_from_sp%computation_accuracy, &
+     sr_from_sp%values / &
+  "SR_from_SP", 1.3032e-10_r8, &
   34.507320124848_r8, 34.50684489445_r8, 34.501667595847_r8, &
   34.504250719214_r8, 34.530454702306_r8, 34.537291790798_r8, &
   34.735859729239_r8, 34.988812913829_r8, 35.120009659207_r8, &
@@ -1108,12 +1124,14 @@ data sr_from_sp / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sp_from_sr
 
-data sp_from_sr / gsw_result( &
-  "SP_from_SR", 1.2971e-10_r8, (/ &
+data sp_from_sr%variable_name, &
+     sp_from_sr%computation_accuracy, &
+     sp_from_sr%values / &
+  "SP_from_SR", 1.2971e-10_r8, &
   34.345367_r8, 34.344894_r8, 34.339741_r8, 34.342312_r8, 34.368393_r8, &
   34.375198_r8, 34.572834_r8, 34.8246_r8, 34.955181_r8, 34.953842_r8, &
   34.821655_r8, 34.670124_r8, 34.442738_r8, 34.430153_r8, 34.455452_r8, &
@@ -1139,12 +1157,14 @@ data sp_from_sr / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sp_from_sa
 
-data sp_from_sa / gsw_result( &
-  "SP_from_SA", 1.2971e-10_r8, (/ &
+data sp_from_sa%variable_name, &
+     sp_from_sa%computation_accuracy, &
+     sp_from_sa%values / &
+  "SP_from_SA", 1.2971e-10_r8, &
   34.345367_r8, 34.344894_r8, 34.339741_r8, 34.342312_r8, 34.368393_r8, &
   34.375198_r8, 34.572834_r8, 34.8246_r8, 34.955181_r8, 34.953842_r8, &
   34.821655_r8, 34.670124_r8, 34.442738_r8, 34.430153_r8, 34.455452_r8, &
@@ -1170,12 +1190,14 @@ data sp_from_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sstar_from_sa
 
-data sstar_from_sa / gsw_result( &
-  "Sstar_from_SA", 1.3e-10_r8, (/ &
+data sstar_from_sa%variable_name, &
+     sstar_from_sa%computation_accuracy, &
+     sstar_from_sa%values / &
+  "Sstar_from_SA", 1.3e-10_r8, &
   34.507257355553_r8, 34.506781861549_r8, 34.501604153914_r8, &
   34.504186106832_r8, 34.530388583505_r8, 34.537224487135_r8, &
   34.735783282747_r8, 34.988715833138_r8, 35.119874921742_r8, &
@@ -1214,12 +1236,14 @@ data sstar_from_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_from_sstar
 
-data sa_from_sstar / gsw_result( &
-  "SA_from_Sstar", 1.3002e-10_r8, (/ &
+data sa_from_sstar%variable_name, &
+     sa_from_sstar%computation_accuracy, &
+     sa_from_sstar%values / &
+  "SA_from_Sstar", 1.3002e-10_r8, &
   34.507499465692_r8, 34.507024988454_r8, 34.501848858511_r8, &
   34.504435326018_r8, 34.530643613166_r8, 34.537484086977_r8, &
   34.736078147786_r8, 34.98909028723_r8, 35.120394623393_r8, &
@@ -1257,12 +1281,14 @@ data sa_from_sstar / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sp_from_sstar
 
-data sp_from_sstar / gsw_result( &
-  "SP_from_Sstar", 1.2971e-10_r8, (/ &
+data sp_from_sstar%variable_name, &
+     sp_from_sstar%computation_accuracy, &
+     sp_from_sstar%values / &
+  "SP_from_Sstar", 1.2971e-10_r8, &
   34.345367_r8, 34.344894_r8, 34.339741_r8, 34.342312_r8, 34.368393_r8, &
   34.375198_r8, 34.572834_r8, 34.8246_r8, 34.955181_r8, 34.953842_r8, &
   34.821655_r8, 34.670124_r8, 34.442738_r8, 34.430153_r8, 34.455452_r8, &
@@ -1288,12 +1314,14 @@ data sp_from_sstar / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_from_ct
 
-data pt_from_ct / gsw_result( &
-  "pt_from_CT", 6.0541e-10_r8, (/ &
+data pt_from_ct%variable_name, &
+     pt_from_ct%computation_accuracy, &
+     pt_from_ct%values / &
+  "pt_from_CT", 6.0541e-10_r8, &
   27.962_r8, 27.960649676263_r8, 27.911304936959_r8, 27.916955275736_r8, &
   27.852620974197_r8, 27.762302527944_r8, 26.926599738775_r8, &
   25.456784362366_r8, 23.380931414239_r8, 20.643430396515_r8, &
@@ -1331,12 +1359,14 @@ data pt_from_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: t_from_ct
 
-data t_from_ct / gsw_result( &
-  "t_from_CT", 6.0001e-10_r8, (/ &
+data t_from_ct%variable_name, &
+     t_from_ct%computation_accuracy, &
+     t_from_ct%values / &
+  "t_from_CT", 6.0001e-10_r8, &
   27.962_r8, 27.963_r8, 27.916_r8, 27.924_r8, 27.862_r8, 27.774_r8, &
   26.944_r8, 25.479_r8, 23.407_r8, 20.672_r8, 18.178_r8, 15.892_r8, &
   12.037_r8, 10.301_r8, 9.2869_r8, 8.4331_r8, 7.2761_r8, 6.5238_r8, &
@@ -1357,12 +1387,14 @@ data t_from_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_from_pt
 
-data ct_from_pt / gsw_result( &
-  "CT_from_pt", 6.2611e-10_r8, (/ &
+data ct_from_pt%variable_name, &
+     ct_from_pt%computation_accuracy, &
+     ct_from_pt%values / &
+  "CT_from_pt", 6.2611e-10_r8, &
   27.994827331979_r8, 27.993492458241_r8, 27.944213680466_r8, &
   27.949774879518_r8, 27.884179948892_r8, 27.793319825682_r8, &
   26.947346080828_r8, 25.46430727652_r8, 23.379820676679_r8, &
@@ -1401,12 +1433,14 @@ data ct_from_pt / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt0_from_t
 
-data pt0_from_t / gsw_result( &
-  "pt0_from_t", 6.054e-10_r8, (/ &
+data pt0_from_t%variable_name, &
+     pt0_from_t%computation_accuracy, &
+     pt0_from_t%values / &
+  "pt0_from_t", 6.054e-10_r8, &
   27.962_r8, 27.960649676263_r8, 27.911304936959_r8, 27.916955275736_r8, &
   27.852620974197_r8, 27.762302527944_r8, 26.926599738775_r8, &
   25.456784362366_r8, 23.380931414239_r8, 20.643430396515_r8, &
@@ -1444,12 +1478,14 @@ data pt0_from_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_from_t
 
-data pt_from_t / gsw_result( &
-  "pt_from_t", 6.054e-10_r8, (/ &
+data pt_from_t%variable_name, &
+     pt_from_t%computation_accuracy, &
+     pt_from_t%values / &
+  "pt_from_t", 6.054e-10_r8, &
   27.962_r8, 27.960649676263_r8, 27.911304936959_r8, 27.916955275736_r8, &
   27.852620974197_r8, 27.762302527944_r8, 26.926599738775_r8, &
   25.456784362366_r8, 23.380931414239_r8, 20.643430396515_r8, &
@@ -1487,12 +1523,14 @@ data pt_from_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: z_from_p
 
-data z_from_p / gsw_result( &
-  "z_from_p", 2.287e-08_r8, (/ &
+data z_from_p%variable_name, &
+     z_from_p%computation_accuracy, &
+     z_from_p%values / &
+  "z_from_p", 2.287e-08_r8, &
   -0._r8, -9.94292752366_r8, -19.8853722291_r8, -29.8273342654_r8, &
   -39.7688137813_r8, -49.7098109259_r8, -75.5541470718_r8, -100.401398555_r8, &
   -125.245640887_r8, -150.086876391_r8, -174.925107385_r8, -200.753682928_r8, &
@@ -1523,12 +1561,14 @@ data z_from_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: p_from_z
 
-data p_from_z / gsw_result( &
-  "p_from_z", 2.3002e-08_r8, (/ &
+data p_from_z%variable_name, &
+     p_from_z%computation_accuracy, &
+     p_from_z%values / &
+  "p_from_z", 2.3002e-08_r8, &
   0._r8, 10._r8, 20._r8, 30._r8, 40._r8, 50._r8, 76._r8, 101._r8, 126._r8, &
   151._r8, 176._r8, 202._r8, 252._r8, 303._r8, 353._r8, 404._r8, 505._r8, &
   606._r8, 707._r8, 808._r8, 909._r8, 1010._r8, 1111._r8, 1213._r8, 1314._r8, &
@@ -1547,12 +1587,14 @@ data p_from_z / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: entropy_from_pt
 
-data entropy_from_pt / gsw_result( &
-  "entropy_from_pt", 9.0282e-09_r8, (/ &
+data entropy_from_pt%variable_name, &
+     entropy_from_pt%computation_accuracy, &
+     entropy_from_pt%values / &
+  "entropy_from_pt", 9.0282e-09_r8, &
   389.65185887387_r8, 389.63428577583_r8, 388.98228296798_r8, &
   389.05534718372_r8, 388.17870752413_r8, 386.9717687749_r8, &
   375.68190926273_r8, 355.83909543977_r8, 327.84182401906_r8, &
@@ -1591,12 +1633,14 @@ data entropy_from_pt / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_from_entropy
 
-data pt_from_entropy / gsw_result( &
-  "pt_from_entropy", 6.0541e-10_r8, (/ &
+data pt_from_entropy%variable_name, &
+     pt_from_entropy%computation_accuracy, &
+     pt_from_entropy%values / &
+  "pt_from_entropy", 6.0541e-10_r8, &
   27.962_r8, 27.960649676263_r8, 27.911304936959_r8, 27.916955275736_r8, &
   27.852620974197_r8, 27.762302527944_r8, 26.926599738775_r8, &
   25.456784362366_r8, 23.380931414239_r8, 20.643430396515_r8, &
@@ -1634,12 +1678,14 @@ data pt_from_entropy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_from_entropy
 
-data ct_from_entropy / gsw_result( &
-  "CT_from_entropy", 6.2611e-10_r8, (/ &
+data ct_from_entropy%variable_name, &
+     ct_from_entropy%computation_accuracy, &
+     ct_from_entropy%values / &
+  "CT_from_entropy", 6.2611e-10_r8, &
   27.994827331979_r8, 27.993492458241_r8, 27.944213680466_r8, &
   27.949774879518_r8, 27.884179948892_r8, 27.793319825682_r8, &
   26.947346080828_r8, 25.46430727652_r8, 23.379820676679_r8, &
@@ -1678,12 +1724,14 @@ data ct_from_entropy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: entropy_from_t
 
-data entropy_from_t / gsw_result( &
-  "entropy_from_t", 9.0282e-09_r8, (/ &
+data entropy_from_t%variable_name, &
+     entropy_from_t%computation_accuracy, &
+     entropy_from_t%values / &
+  "entropy_from_t", 9.0282e-09_r8, &
   389.65185887387_r8, 389.63428577583_r8, 388.98228296798_r8, &
   389.05534718372_r8, 388.17870752413_r8, 386.9717687749_r8, &
   375.68190926273_r8, 355.83909543977_r8, 327.84182401906_r8, &
@@ -1722,12 +1770,14 @@ data entropy_from_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: adiabatic_lapse_rate_from_ct
 
-data adiabatic_lapse_rate_from_ct / gsw_result( &
-  "adiabatic_lapse_rate_from_CT", 5.6997e-19_r8, (/ &
+data adiabatic_lapse_rate_from_ct%variable_name, &
+     adiabatic_lapse_rate_from_ct%computation_accuracy, &
+     adiabatic_lapse_rate_from_ct%values / &
+  "adiabatic_lapse_rate_from_CT", 5.6997e-19_r8, &
   2.350076231702e-08_r8, 2.3506593895185e-08_r8, 2.3482041606441e-08_r8, &
   2.3492497567774e-08_r8, 2.3461041657227e-08_r8, 2.3411854306218e-08_r8, &
   2.2921721022123e-08_r8, 2.2033388669692e-08_r8, 2.074072990348e-08_r8, &
@@ -1766,12 +1816,14 @@ data adiabatic_lapse_rate_from_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: specvol
 
-data specvol / gsw_result( &
-  "specvol", 2.8211e-16_r8, (/ &
+data specvol%variable_name, &
+     specvol%computation_accuracy, &
+     specvol%values / &
+  "specvol", 2.8211e-16_r8, &
   0.0009785543233027595_r8, 0.0009785138871230684_r8, &
   0.0009784618366719601_r8, 0.000978421415045363_r8, &
   0.0009783422466640218_r8, 0.0009782688824288848_r8, &
@@ -1824,12 +1876,14 @@ data specvol / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: alpha
 
-data alpha / gsw_result( &
-  "alpha", 8.2511e-15_r8, (/ &
+data alpha%variable_name, &
+     alpha%computation_accuracy, &
+     alpha%values / &
+  "alpha", 8.2511e-15_r8, &
   0.00031831246465714_r8, 0.00031840612786134_r8, 0.00031814275657959_r8, &
   0.00031829167734161_r8, 0.00031795922055419_r8, 0.00031741177706767_r8, &
   0.00031179395602026_r8, 0.00030141362492837_r8, 0.00028596263812853_r8, &
@@ -1868,12 +1922,14 @@ data alpha / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: beta
 
-data beta / gsw_result( &
-  "beta", 1.8397e-15_r8, (/ &
+data beta%variable_name, &
+     beta%computation_accuracy, &
+     beta%values / &
+  "beta", 1.8397e-15_r8, &
   0.00071891860085091_r8, 0.00071883031010036_r8, 0.00071881933367617_r8, &
   0.00071871921576397_r8, 0.00071872418757004_r8, 0.00071877529859646_r8, &
   0.00071982423795744_r8, 0.00072192226059341_r8, 0.00072514590519558_r8, &
@@ -1912,12 +1968,14 @@ data beta / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: alpha_on_beta
 
-data alpha_on_beta / gsw_result( &
-  "alpha_on_beta", 1.0514e-11_r8, (/ &
+data alpha_on_beta%variable_name, &
+     alpha_on_beta%computation_accuracy, &
+     alpha_on_beta%values / &
+  "alpha_on_beta", 1.0514e-11_r8, &
   0.44276565424847_r8, 0.44295033666135_r8, 0.44259070628019_r8, &
   0.44285956234422_r8, 0.4423939336579_r8, 0.44160084199815_r8, &
   0.43315289980371_r8, 0.41751534947906_r8, 0.39435186226613_r8, &
@@ -1956,12 +2014,14 @@ data alpha_on_beta / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_vab
 
-data v_vab / gsw_result( &
-  "v_vab", 2.8211e-16_r8, (/ &
+data v_vab%variable_name, &
+     v_vab%computation_accuracy, &
+     v_vab%values / &
+  "v_vab", 2.8211e-16_r8, &
   0.0009785543233027595_r8, 0.0009785138871230684_r8, &
   0.0009784618366719601_r8, 0.000978421415045363_r8, &
   0.0009783422466640218_r8, 0.0009782688824288848_r8, &
@@ -2014,12 +2074,14 @@ data v_vab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: alpha_vab
 
-data alpha_vab / gsw_result( &
-  "alpha_vab", 8.2511e-15_r8, (/ &
+data alpha_vab%variable_name, &
+     alpha_vab%computation_accuracy, &
+     alpha_vab%values / &
+  "alpha_vab", 8.2511e-15_r8, &
   0.00031831246465714_r8, 0.00031840612786134_r8, 0.00031814275657959_r8, &
   0.00031829167734161_r8, 0.00031795922055419_r8, 0.00031741177706767_r8, &
   0.00031179395602026_r8, 0.00030141362492837_r8, 0.00028596263812853_r8, &
@@ -2058,12 +2120,14 @@ data alpha_vab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: beta_vab
 
-data beta_vab / gsw_result( &
-  "beta_vab", 1.8397e-15_r8, (/ &
+data beta_vab%variable_name, &
+     beta_vab%computation_accuracy, &
+     beta_vab%values / &
+  "beta_vab", 1.8397e-15_r8, &
   0.00071891860085091_r8, 0.00071883031010036_r8, 0.00071881933367617_r8, &
   0.00071871921576397_r8, 0.00071872418757004_r8, 0.00071877529859646_r8, &
   0.00071982423795744_r8, 0.00072192226059341_r8, 0.00072514590519558_r8, &
@@ -2102,12 +2166,14 @@ data beta_vab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa
 
-data v_sa / gsw_result( &
-  "v_SA", 1.7416e-18_r8, (/ &
+data v_sa%variable_name, &
+     v_sa%computation_accuracy, &
+     v_sa%values / &
+  "v_SA", 1.7416e-18_r8, &
   -7.0350090496543e-07_r8, -7.0338544091818e-07_r8, -7.033372854641e-07_r8, &
   -7.0321027210807e-07_r8, -7.0315823639905e-07_r8, -7.0315550807545e-07_r8, &
   -7.0381825016283e-07_r8, -7.053471945702e-07_r8, -7.0792250710446e-07_r8, &
@@ -2146,12 +2212,14 @@ data v_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_ct
 
-data v_ct / gsw_result( &
-  "v_CT", 8.2012e-18_r8, (/ &
+data v_ct%variable_name, &
+     v_ct%computation_accuracy, &
+     v_ct%values / &
+  "v_CT", 8.2012e-18_r8, &
   3.1148603845141e-07_r8, 3.115648178574e-07_r8, 3.1129054592675e-07_r8, &
   3.1142339334174e-07_r8, 3.1107293818453e-07_r8, 3.1051406442176e-07_r8, &
   3.0486091599281e-07_r8, 2.9449328044505e-07_r8, 2.7917055901675e-07_r8, &
@@ -2190,12 +2258,14 @@ data v_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_p
 
-data v_p / gsw_result( &
-  "v_P", 1.6498e-24_r8, (/ &
+data v_p%variable_name, &
+     v_p%computation_accuracy, &
+     v_p%values / &
+  "v_P", 1.6498e-24_r8, &
   -4.0360175735096e-13_r8, -4.0348025948621e-13_r8, -4.0340707765012e-13_r8, &
   -4.0327593314869e-13_r8, -4.0318060668652e-13_r8, -4.0313089243725e-13_r8, &
   -4.0335051227667e-13_r8, -4.0417070999173e-13_r8, -4.0587836313488e-13_r8, &
@@ -2234,12 +2304,14 @@ data v_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_sa
 
-data v_sa_sa / gsw_result( &
-  "v_SA_SA", 1.9904e-20_r8, (/ &
+data v_sa_sa%variable_name, &
+     v_sa_sa%computation_accuracy, &
+     v_sa_sa%values / &
+  "v_SA_SA", 1.9904e-20_r8, &
   8.1412919788949e-10_r8, 8.1381381955419e-10_r8, 8.1378220039767e-10_r8, &
   8.134172498147e-10_r8, 8.1338638276558e-10_r8, 8.1355870308432e-10_r8, &
   8.1724659181481e-10_r8, 8.2576501487383e-10_r8, 8.4064999681862e-10_r8, &
@@ -2278,12 +2350,14 @@ data v_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_ct
 
-data v_sa_ct / gsw_result( &
-  "v_SA_CT", 6.3274e-20_r8, (/ &
+data v_sa_ct%variable_name, &
+     v_sa_ct%computation_accuracy, &
+     v_sa_ct%values / &
+  "v_SA_CT", 6.3274e-20_r8, &
   1.3238829406898e-09_r8, 1.3231062189366e-09_r8, 1.323768839051e-09_r8, &
   1.3227696556965e-09_r8, 1.3237377549725e-09_r8, 1.3255743423394e-09_r8, &
   1.3483026097811e-09_r8, 1.3945080475859e-09_r8, 1.4709734467797e-09_r8, &
@@ -2322,12 +2396,14 @@ data v_sa_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_ct_ct
 
-data v_ct_ct / gsw_result( &
-  "v_CT_CT", 2.2094e-19_r8, (/ &
+data v_ct_ct%variable_name, &
+     v_ct_ct%computation_accuracy, &
+     v_ct_ct%values / &
+  "v_CT_CT", 2.2094e-19_r8, &
   7.2390425622836e-09_r8, 7.2349222950512e-09_r8, 7.2362841226129e-09_r8, &
   7.2313008273788e-09_r8, 7.2335294971141e-09_r8, 7.2391121782991e-09_r8, &
   7.3151621308933e-09_r8, 7.4587383840231e-09_r8, 7.6742954425614e-09_r8, &
@@ -2366,12 +2442,14 @@ data v_ct_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_p
 
-data v_sa_p / gsw_result( &
-  "v_SA_P", 1.3036e-26_r8, (/ &
+data v_sa_p%variable_name, &
+     v_sa_p%computation_accuracy, &
+     v_sa_p%values / &
+  "v_SA_P", 1.3036e-26_r8, &
   1.4194515708872e-15_r8, 1.4188157294008e-15_r8, 1.4186156672177e-15_r8, &
   1.4179370276469e-15_r8, 1.4181566529851e-15_r8, 1.4184712825436e-15_r8, &
   1.4269921283193e-15_r8, 1.4432041247703e-15_r8, 1.4663725278715e-15_r8, &
@@ -2410,12 +2488,14 @@ data v_sa_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_ct_p
 
-data v_ct_p / gsw_result( &
-  "v_CT_P", 6.6142e-26_r8, (/ &
+data v_ct_p%variable_name, &
+     v_ct_p%computation_accuracy, &
+     v_ct_p%values / &
+  "v_CT_P", 6.6142e-26_r8, &
   8.908400568972e-16_r8, 8.9051649960549e-16_r8, 8.9228549949584e-16_r8, &
   8.9163973744734e-16_r8, 8.9385164457418e-16_r8, 8.973133793556e-16_r8, &
   9.315060288388e-16_r8, 9.9523832311009e-16_r8, 1.0923039158051e-15_r8, &
@@ -2454,12 +2534,14 @@ data v_ct_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_wrt_h
 
-data v_sa_wrt_h / gsw_result( &
-  "v_SA_wrt_h", 1.7425e-18_r8, (/ &
+data v_sa_wrt_h%variable_name, &
+     v_sa_wrt_h%computation_accuracy, &
+     v_sa_wrt_h%values / &
+  "v_SA_wrt_h", 1.7425e-18_r8, &
   -7.0350090496543e-07_r8, -7.0337995058708e-07_r8, -7.0332631438749e-07_r8, &
   -7.0319381019625e-07_r8, -7.0313631184252e-07_r8, -7.0312814964384e-07_r8, &
   -7.0377737574994e-07_r8, -7.0529459744142e-07_r8, -7.0786006472622e-07_r8, &
@@ -2498,12 +2580,14 @@ data v_sa_wrt_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_h
 
-data v_h / gsw_result( &
-  "v_h", 2.0545e-21_r8, (/ &
+data v_h%variable_name, &
+     v_h%computation_accuracy, &
+     v_h%values / &
+  "v_h", 2.0545e-21_r8, &
   7.8030145735622e-11_r8, 7.8049271621969e-11_r8, 7.7979957197452e-11_r8, &
   7.8012627504545e-11_r8, 7.7924232728479e-11_r8, 7.7783634136147e-11_r8, &
   7.6366063770729e-11_r8, 7.3767814902939e-11_r8, 6.9928671239267e-11_r8, &
@@ -2542,12 +2626,14 @@ data v_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_sa_wrt_h
 
-data v_sa_sa_wrt_h / gsw_result( &
-  "v_SA_SA_wrt_h", 1.9904e-20_r8, (/ &
+data v_sa_sa_wrt_h%variable_name, &
+     v_sa_sa_wrt_h%computation_accuracy, &
+     v_sa_sa_wrt_h%values / &
+  "v_SA_SA_wrt_h", 1.9904e-20_r8, &
   8.1412919788949e-10_r8, 8.1386680582943e-10_r8, 8.1388821556645e-10_r8, &
   8.1357616214863e-10_r8, 8.135983868891e-10_r8, 8.1382401563021e-10_r8, &
   8.1765577468428e-10_r8, 8.2632502420474e-10_r8, 8.4138266707933e-10_r8, &
@@ -2586,12 +2672,14 @@ data v_sa_sa_wrt_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_sa_h
 
-data v_sa_h / gsw_result( &
-  "v_SA_h", 1.5896e-23_r8, (/ &
+data v_sa_h%variable_name, &
+     v_sa_h%computation_accuracy, &
+     v_sa_h%values / &
+  "v_SA_h", 1.5896e-23_r8, &
   3.3164497295773e-13_r8, 3.3147716015111e-13_r8, 3.3166993053927e-13_r8, &
   3.3144632282805e-13_r8, 3.3171563099318e-13_r8, 3.3220261133056e-13_r8, &
   3.3796876451079e-13_r8, 3.4961878959215e-13_r8, 3.6885745036872e-13_r8, &
@@ -2630,12 +2718,14 @@ data v_sa_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: v_h_h
 
-data v_h_h / gsw_result( &
-  "v_h_h", 1.3867e-26_r8, (/ &
+data v_h_h%variable_name, &
+     v_h_h%computation_accuracy, &
+     v_h_h%values / &
+  "v_h_h", 1.3867e-26_r8, &
   4.542854167654e-16_r8, 4.5401621890076e-16_r8, 4.5409106434954e-16_r8, &
   4.5376772347679e-16_r8, 4.5389699822474e-16_r8, 4.5423678237247e-16_r8, &
   4.5898236888969e-16_r8, 4.679678027577e-16_r8, 4.8147241690101e-16_r8, &
@@ -2674,12 +2764,14 @@ data v_h_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: specvol_anom_standard
 
-data specvol_anom_standard / gsw_result( &
-  "specvol_anom_standard", 2.8059e-16_r8, (/ &
+data specvol_anom_standard%variable_name, &
+     specvol_anom_standard%computation_accuracy, &
+     specvol_anom_standard%values / &
+  "specvol_anom_standard", 2.8059e-16_r8, &
   5.8929378183726e-06_r8, 5.8975536407299e-06_r8, 5.8905409342067e-06_r8, &
   5.895142798727e-06_r8, 5.8609836590313e-06_r8, 5.8326144200652e-06_r8, &
   5.4446856278501e-06_r8, 4.8333577576099e-06_r8, 4.1535976592016e-06_r8, &
@@ -2718,12 +2810,14 @@ data specvol_anom_standard / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho
 
-data rho / gsw_result( &
-  "rho", 2.9468e-10_r8, (/ &
+data rho%variable_name, &
+     rho%computation_accuracy, &
+     rho%values / &
+  "rho", 2.9468e-10_r8, &
   1021.91567313796_r8, 1021.957902856242_r8, 1022.012267132766_r8, &
   1022.05448963281_r8, 1022.137195250259_r8, 1022.213849342893_r8, &
   1022.741649269399_r8, 1023.499159209548_r8, 1024.329496404296_r8, &
@@ -2762,12 +2856,14 @@ data rho / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_rab
 
-data rho_rab / gsw_result( &
-  "rho_rab", 2.9468e-10_r8, (/ &
+data rho_rab%variable_name, &
+     rho_rab%computation_accuracy, &
+     rho_rab%values / &
+  "rho_rab", 2.9468e-10_r8, &
   1021.91567313796_r8, 1021.957902856242_r8, 1022.012267132766_r8, &
   1022.05448963281_r8, 1022.137195250259_r8, 1022.213849342893_r8, &
   1022.741649269399_r8, 1023.499159209548_r8, 1024.329496404296_r8, &
@@ -2806,12 +2902,14 @@ data rho_rab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: alpha_rab
 
-data alpha_rab / gsw_result( &
-  "alpha_rab", 8.2511e-15_r8, (/ &
+data alpha_rab%variable_name, &
+     alpha_rab%computation_accuracy, &
+     alpha_rab%values / &
+  "alpha_rab", 8.2511e-15_r8, &
   0.00031831246465714_r8, 0.00031840612786134_r8, 0.00031814275657959_r8, &
   0.00031829167734161_r8, 0.00031795922055419_r8, 0.00031741177706767_r8, &
   0.00031179395602026_r8, 0.00030141362492837_r8, 0.00028596263812853_r8, &
@@ -2850,12 +2948,14 @@ data alpha_rab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: beta_rab
 
-data beta_rab / gsw_result( &
-  "beta_rab", 1.8397e-15_r8, (/ &
+data beta_rab%variable_name, &
+     beta_rab%computation_accuracy, &
+     beta_rab%values / &
+  "beta_rab", 1.8397e-15_r8, &
   0.00071891860085091_r8, 0.00071883031010036_r8, 0.00071881933367617_r8, &
   0.00071871921576397_r8, 0.00071872418757004_r8, 0.00071877529859646_r8, &
   0.00071982423795744_r8, 0.00072192226059341_r8, 0.00072514590519558_r8, &
@@ -2894,12 +2994,14 @@ data beta_rab / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa
 
-data rho_sa / gsw_result( &
-  "rho_SA", 1.9391e-12_r8, (/ &
+data rho_sa%variable_name, &
+     rho_sa%computation_accuracy, &
+     rho_sa%values / &
+  "rho_SA", 1.9391e-12_r8, &
   0.73467418591996_r8, 0.73461431621966_r8, 0.73464217686925_r8, &
   0.73457020125693_r8, 0.73463472524136_r8, 0.73474206479087_r8, &
   0.73619422831268_r8, 0.73888682673201_r8, 0.74278833988862_r8, &
@@ -2938,12 +3040,14 @@ data rho_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_ct
 
-data rho_ct / gsw_result( &
-  "rho_CT", 8.3013e-12_r8, (/ &
+data rho_ct%variable_name, &
+     rho_ct%computation_accuracy, &
+     rho_ct%values / &
+  "rho_CT", 8.3013e-12_r8, &
   -0.325288496588_r8, -0.325397658686_r8, -0.325145799924_r8, &
   -0.32531143784_r8, -0.324997945901_r8, -0.324462714463_r8, &
   -0.318884664812_r8, -0.308496591688_r8, -0.292919965105_r8, &
@@ -2982,12 +3086,14 @@ data rho_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_p
 
-data rho_p / gsw_result( &
-  "rho_P", 1.7791e-18_r8, (/ &
+data rho_p%variable_name, &
+     rho_p%computation_accuracy, &
+     rho_p%values / &
+  "rho_P", 1.7791e-18_r8, &
   4.2148601433889e-07_r8, 4.2139395797513e-07_r8, 4.2136235318989e-07_r8, &
   4.2126017654302e-07_r8, 4.2122876314814e-07_r8, 4.2123999725329e-07_r8, &
   4.2190482991361e-07_r8, 4.233892410188e-07_r8, 4.2586824479248e-07_r8, &
@@ -3026,12 +3132,14 @@ data rho_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_sa
 
-data rho_sa_sa / gsw_result( &
-  "rho_SA_SA", 1.946e-14_r8, (/ &
+data rho_sa_sa%variable_name, &
+     rho_sa_sa%computation_accuracy, &
+     rho_sa_sa%values / &
+  "rho_SA_SA", 1.946e-14_r8, &
   0.00020613727537939_r8, 0.00020618058440038_r8, 0.00020614710742184_r8, &
   0.00020620753695328_r8, 0.00020620231861555_r8, 0.0002061241953214_r8, &
   0.00020502057051094_r8, 0.00020180711847375_r8, 0.00019520706598513_r8, &
@@ -3070,12 +3178,14 @@ data rho_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_ct
 
-data rho_sa_ct / gsw_result( &
-  "rho_SA_CT", 5.1778e-14_r8, (/ &
+data rho_sa_ct%variable_name, &
+     rho_sa_ct%computation_accuracy, &
+     rho_sa_ct%values / &
+  "rho_SA_CT", 5.1778e-14_r8, &
   -0.0018502582706184_r8, -0.0018496608293815_r8, -0.0018501307389897_r8, &
   -0.0018493742338183_r8, -0.0018501619113689_r8, -0.0018515522401729_r8, &
   -0.001869407000257_r8, -0.0019062387565219_r8, -0.0019682396647075_r8, &
@@ -3114,12 +3224,14 @@ data rho_sa_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_ct_ct
 
-data rho_ct_ct / gsw_result( &
-  "rho_CT_CT", 2.2724e-13_r8, (/ &
+data rho_ct_ct%variable_name, &
+     rho_ct_ct%computation_accuracy, &
+     rho_ct_ct%values / &
+  "rho_CT_CT", 2.2724e-13_r8, &
   -0.0073527296658543_r8, -0.0073489208340225_r8, -0.0073514788671844_r8, &
   -0.007346695587652_r8, -0.0073506622499345_r8, -0.0073583248761721_r8, &
   -0.0074528104862947_r8, -0.0076274351871721_r8, -0.0078847332000374_r8, &
@@ -3158,12 +3270,14 @@ data rho_ct_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_p
 
-data rho_sa_p / gsw_result( &
-  "rho_SA_P", 1.1e-20_r8, (/ &
+data rho_sa_p%variable_name, &
+     rho_sa_p%computation_accuracy, &
+     rho_sa_p%values / &
+  "rho_SA_P", 1.1e-20_r8, &
   -8.7632153074573e-10_r8, -8.7598674763513e-10_r8, -8.7599012525601e-10_r8, &
   -8.7563490046175e-10_r8, -8.7614504862574e-10_r8, -8.7663683955821e-10_r8, &
   -8.8523980745339e-10_r8, -9.0052100824322e-10_r8, -9.2095949210354e-10_r8, &
@@ -3202,12 +3316,14 @@ data rho_sa_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_ct_p
 
-data rho_ct_p / gsw_result( &
-  "rho_CT_P", 5.9599e-20_r8, (/ &
+data rho_ct_p%variable_name, &
+     rho_ct_p%computation_accuracy, &
+     rho_ct_p%values / &
+  "rho_CT_P", 5.9599e-20_r8, &
   -1.1986431475584e-09_r8, -1.1984024481951e-09_r8, -1.200107062099e-09_r8, &
   -1.1995699665427e-09_r8, -1.2017315565841e-09_r8, -1.2050348038663e-09_r8, &
   -1.2374505063254e-09_r8, -1.2977930035405e-09_r8, -1.389665699076e-09_r8, &
@@ -3246,12 +3362,14 @@ data rho_ct_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_wrt_h
 
-data rho_sa_wrt_h / gsw_result( &
-  "rho_SA_wrt_h", 1.9399e-12_r8, (/ &
+data rho_sa_wrt_h%variable_name, &
+     rho_sa_wrt_h%computation_accuracy, &
+     rho_sa_wrt_h%values / &
+  "rho_SA_wrt_h", 1.9399e-12_r8, &
   0.73467418591996_r8, 0.73460858212909_r8, 0.73463071748018_r8, &
   0.7345530052199_r8, 0.73461181924421_r8, 0.73471347738695_r8, &
   0.73615147365712_r8, 0.73883172858194_r8, 0.74272282216598_r8, &
@@ -3290,12 +3408,14 @@ data rho_sa_wrt_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_h
 
-data rho_h / gsw_result( &
-  "rho_h", 2.0795e-15_r8, (/ &
+data rho_h%variable_name, &
+     rho_h%computation_accuracy, &
+     rho_h%values / &
+  "rho_h", 2.0795e-15_r8, &
   -8.14877896971e-05_r8, -8.15144996876e-05_r8, -8.14507728961e-05_r8, &
   -8.14916302556e-05_r8, -8.14124678298e-05_r8, -8.12777647274e-05_r8, &
   -7.98789394477e-05_r8, -7.72755135176e-05_r8, -7.33727224366e-05_r8, &
@@ -3334,12 +3454,14 @@ data rho_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_sa_wrt_h
 
-data rho_sa_sa_wrt_h / gsw_result( &
-  "rho_SA_SA_wrt_h", 1.946e-14_r8, (/ &
+data rho_sa_sa_wrt_h%variable_name, &
+     rho_sa_sa_wrt_h%computation_accuracy, &
+     rho_sa_sa_wrt_h%values / &
+  "rho_SA_SA_wrt_h", 1.946e-14_r8, &
   0.00020613727537939_r8, 0.0002061087583548_r8, 0.00020600342495137_r8, &
   0.00020599210195312_r8, 0.00020591497289479_r8, 0.00020576477454965_r8, &
   0.00020446946525781_r8, 0.00020106138001096_r8, 0.00019424827979015_r8, &
@@ -3378,12 +3500,14 @@ data rho_sa_sa_wrt_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_sa_h
 
-data rho_sa_h / gsw_result( &
-  "rho_SA_h", 1.3135e-17_r8, (/ &
+data rho_sa_h%variable_name, &
+     rho_sa_h%computation_accuracy, &
+     rho_sa_h%values / &
+  "rho_SA_h", 1.3135e-17_r8, &
   -4.6350688211476e-07_r8, -4.6338333969969e-07_r8, -4.6352720613296e-07_r8, &
   -4.6336375645948e-07_r8, -4.6358726812249e-07_r8, -4.6396188909023e-07_r8, &
   -4.6850640521299e-07_r8, -4.7780885480227e-07_r8, -4.9342649050382e-07_r8, &
@@ -3422,12 +3546,14 @@ data rho_sa_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_h_h
 
-data rho_h_h / gsw_result( &
-  "rho_h_h", 1.4263e-20_r8, (/ &
+data rho_h_h%variable_name, &
+     rho_h_h%computation_accuracy, &
+     rho_h_h%values / &
+  "rho_h_h", 1.4263e-20_r8, &
   -4.6141983996876e-10_r8, -4.6116991717184e-10_r8, -4.613195585917e-10_r8, &
   -4.6100849766995e-10_r8, -4.6124656075756e-10_r8, -4.6171658743833e-10_r8, &
   -4.6761824838173e-10_r8, -4.7855111636706e-10_r8, -4.946739987382e-10_r8, &
@@ -3466,12 +3592,14 @@ data rho_h_h / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sigma0
 
-data sigma0 / gsw_result( &
-  "sigma0", 2.9308e-10_r8, (/ &
+data sigma0%variable_name, &
+     sigma0%computation_accuracy, &
+     sigma0%values / &
+  "sigma0", 2.9308e-10_r8, &
   21.91567313796_r8, 21.915758763153_r8, 21.92797587457_r8, &
   21.928069319644_r8, 21.968628624375_r8, 22.003111966245_r8, &
   22.420729987886_r8, 23.071054644127_r8, 23.792148470519_r8, &
@@ -3510,12 +3638,14 @@ data sigma0 / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sigma1
 
-data sigma1 / gsw_result( &
-  "sigma1", 2.9945e-10_r8, (/ &
+data sigma1%variable_name, &
+     sigma1%computation_accuracy, &
+     sigma1%values / &
+  "sigma1", 2.9945e-10_r8, &
   26.084138104742_r8, 26.084242415463_r8, 26.097074557038_r8, &
   26.097086323044_r8, 26.138263521206_r8, 26.173785342968_r8, &
   26.600396019988_r8, 27.267741784268_r8, 28.015722626613_r8, &
@@ -3554,12 +3684,14 @@ data sigma1 / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sigma2
 
-data sigma2 / gsw_result( &
-  "sigma2", 3.0559e-10_r8, (/ &
+data sigma2%variable_name, &
+     sigma2%computation_accuracy, &
+     sigma2%values / &
+  "sigma2", 3.0559e-10_r8, &
   30.162087602062_r8, 30.162210017706_r8, 30.175638901372_r8, &
   30.175571564622_r8, 30.217350742656_r8, 30.253881413036_r8, &
   30.689239857888_r8, 31.373137012335_r8, 32.147248923553_r8, &
@@ -3598,12 +3730,14 @@ data sigma2 / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sigma3
 
-data sigma3 / gsw_result( &
-  "sigma3", 3.1173e-10_r8, (/ &
+data sigma3%variable_name, &
+     sigma3%computation_accuracy, &
+     sigma3%values / &
+  "sigma3", 3.1173e-10_r8, &
   34.152743058376_r8, 34.1528829535_r8, 34.166888774414_r8, &
   34.166745105744_r8, 34.209108700656_r8, 34.246615943491_r8, &
   34.690452931711_r8, 35.390382549122_r8, 36.189786234199_r8, &
@@ -3641,12 +3775,14 @@ data sigma3 / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sigma4
 
-data sigma4 / gsw_result( &
-  "sigma4", 3.1741e-10_r8, (/ &
+data sigma4%variable_name, &
+     sigma4%computation_accuracy, &
+     sigma4%values / &
+  "sigma4", 3.1741e-10_r8, &
   38.059063992319_r8, 38.059220722781_r8, 38.073783145936_r8, &
   38.073566002913_r8, 38.11649617402_r8, 38.154946916142_r8, &
   38.606986324042_r8, 39.32241063972_r8, 40.146225672342_r8, &
@@ -3685,12 +3821,14 @@ data sigma4 / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sound_speed
 
-data sound_speed / gsw_result( &
-  "sound_speed", 2.5918e-09_r8, (/ &
+data sound_speed%variable_name, &
+     sound_speed%computation_accuracy, &
+     sound_speed%values / &
+  "sound_speed", 2.5918e-09_r8, &
   1540.3109958442_r8, 1540.4792323405_r8, 1540.5370039972_r8, &
   1540.7238212785_r8, 1540.7812704222_r8, 1540.7607246356_r8, &
   1539.5462897252_r8, 1536.8450800569_r8, 1532.3655193859_r8, &
@@ -3729,12 +3867,14 @@ data sound_speed / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: kappa
 
-data kappa / gsw_result( &
-  "kappa", 1.714e-21_r8, (/ &
+data kappa%variable_name, &
+     kappa%computation_accuracy, &
+     kappa%values / &
+  "kappa", 1.714e-21_r8, &
   4.1244696154297e-10_r8, 4.1233983982842e-10_r8, 4.122869820066e-10_r8, &
   4.1216997803548e-10_r8, 4.1210589449785e-10_r8, 4.1208598134732e-10_r8, &
   4.125233681595e-10_r8, 4.1366838185366e-10_r8, 4.1575317931135e-10_r8, &
@@ -3773,12 +3913,14 @@ data kappa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: cabbeling
 
-data cabbeling / gsw_result( &
-  "cabbeling", 1.5877e-16_r8, (/ &
+data cabbeling%variable_name, &
+     cabbeling%computation_accuracy, &
+     cabbeling%values / &
+  "cabbeling", 1.5877e-16_r8, &
   8.7588243173554e-06_r8, 8.7548449123664e-06_r8, 8.7560580765147e-06_r8, &
   8.7512744544768e-06_r8, 8.7535281507586e-06_r8, 8.758854510151e-06_r8, &
   8.8329465856152e-06_r8, 8.9731624663844e-06_r8, 9.1833085687301e-06_r8, &
@@ -3817,12 +3959,14 @@ data cabbeling / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: thermobaric
 
-data thermobaric / gsw_result( &
-  "thermobaric", 5.1742e-23_r8, (/ &
+data thermobaric%variable_name, &
+     thermobaric%computation_accuracy, &
+     thermobaric%values / &
+  "thermobaric", 5.1742e-23_r8, &
   1.5526214786187e-12_r8, 1.5523350507267e-12_r8, 1.5536135929024e-12_r8, &
   1.5531004182612e-12_r8, 1.5549114331089e-12_r8, 1.5575589896041e-12_r8, &
   1.5848525354408e-12_r8, 1.6353451118641e-12_r8, 1.7112147956412e-12_r8, &
@@ -3861,12 +4005,14 @@ data thermobaric / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_from_rho
 
-data sa_from_rho / gsw_result( &
-  "SA_from_rho", 1.3051e-10_r8, (/ &
+data sa_from_rho%variable_name, &
+     sa_from_rho%computation_accuracy, &
+     sa_from_rho%values / &
+  "SA_from_rho", 1.3051e-10_r8, &
   34.507499465692_r8, 34.507024988455_r8, 34.501848858511_r8, &
   34.504435326018_r8, 34.530643613166_r8, 34.537484086977_r8, &
   34.736078147786_r8, 34.989090287231_r8, 35.120394623393_r8, &
@@ -3904,12 +4050,14 @@ data sa_from_rho / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_from_rho
 
-data ct_from_rho / gsw_result( &
-  "CT_from_rho", 6.2856e-10_r8, (/ &
+data ct_from_rho%variable_name, &
+     ct_from_rho%computation_accuracy, &
+     ct_from_rho%values / &
+  "CT_from_rho", 6.2856e-10_r8, &
   27.994827331979_r8, 27.993492458241_r8, 27.944213680466_r8, &
   27.949774879518_r8, 27.884179948892_r8, 27.793319825682_r8, &
   26.947346080828_r8, 25.464307276521_r8, 23.37982067668_r8, &
@@ -3947,12 +4095,14 @@ data ct_from_rho / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_maxdensity
 
-data ct_maxdensity / gsw_result( &
-  "CT_maxdensity", 6.904e-11_r8, (/ &
+data ct_maxdensity%variable_name, &
+     ct_maxdensity%computation_accuracy, &
+     ct_maxdensity%values / &
+  "CT_maxdensity", 6.904e-11_r8, &
   -3.6640510449813_r8, -3.6865300504791_r8, -3.7079898915943_r8, &
   -3.7311634544798_r8, -3.7595255266563_r8, -3.7836531675534_r8, &
   -3.8860100066592_r8, -3.9979679594893_r8, -4.083335008031_r8, &
@@ -3991,12 +4141,14 @@ data ct_maxdensity / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: internal_energy
 
-data internal_energy / gsw_result( &
-  "internal_energy", 2.4993e-06_r8, (/ &
+data internal_energy%variable_name, &
+     internal_energy%computation_accuracy, &
+     internal_energy%values / &
+  "internal_energy", 2.4993e-06_r8, &
   111652.50217481_r8, 111647.17964992_r8, 111450.47660214_r8, &
   111472.69035333_r8, 111210.86618798_r8, 110848.19015662_r8, &
   107471.29198658_r8, 101551.36001111_r8, 93230.561237194_r8, &
@@ -4035,12 +4187,14 @@ data internal_energy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: enthalpy
 
-data enthalpy / gsw_result( &
-  "enthalpy", 2.4994e-06_r8, (/ &
+data enthalpy%variable_name, &
+     enthalpy%computation_accuracy, &
+     enthalpy%values / &
+  "enthalpy", 2.4994e-06_r8, &
   111751.65419162_r8, 111844.17895824_r8, 111745.31161508_r8, &
   111865.35532773_r8, 111701.33361479_r8, 111436.44769234_r8, &
   108313.46459255_r8, 102637.16940333_r8, 94559.552547879_r8, &
@@ -4079,12 +4233,14 @@ data enthalpy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: enthalpy_diff
 
-data enthalpy_diff / gsw_result( &
-  "enthalpy_diff", 3.0752e-11_r8, (/ &
+data enthalpy_diff%variable_name, &
+     enthalpy_diff%computation_accuracy, &
+     enthalpy_diff%values / &
+  "enthalpy_diff", 3.0752e-11_r8, &
   97.85341452692198_r8, 97.84937151634202_r8, 97.84416683707531_r8, &
   97.84012533003096_r8, 97.83220896844693_r8, 97.82487279345622_r8, &
   97.77438678126379_r8, 97.70201662485873_r8, 97.62280769716332_r8, &
@@ -4123,12 +4279,14 @@ data enthalpy_diff / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_from_enthalpy
 
-data ct_from_enthalpy / gsw_result( &
-  "CT_from_enthalpy", 6.2611e-10_r8, (/ &
+data ct_from_enthalpy%variable_name, &
+     ct_from_enthalpy%computation_accuracy, &
+     ct_from_enthalpy%values / &
+  "CT_from_enthalpy", 6.2611e-10_r8, &
   27.994827331979_r8, 27.993492458241_r8, 27.944213680466_r8, &
   27.949774879518_r8, 27.884179948892_r8, 27.793319825682_r8, &
   26.947346080828_r8, 25.46430727652_r8, 23.379820676679_r8, &
@@ -4167,12 +4325,14 @@ data ct_from_enthalpy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: dynamic_enthalpy
 
-data dynamic_enthalpy / gsw_result( &
-  "dynamic_enthalpy", 2.2888e-07_r8, (/ &
+data dynamic_enthalpy%variable_name, &
+     dynamic_enthalpy%computation_accuracy, &
+     dynamic_enthalpy%values / &
+  "dynamic_enthalpy", 2.2888e-07_r8, &
   0._r8, 97.853406318988_r8, 195.70043711869_r8, 293.54457747267_r8, &
   391.36916624726_r8, 489.18485822373_r8, 743.21724307628_r8, &
   987.01713593714_r8, 1230.3955454424_r8, 1473.3371450362_r8, &
@@ -4210,12 +4370,14 @@ data dynamic_enthalpy / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa
 
-data h_sa / gsw_result( &
-  "h_SA", 2.3732e-10_r8, (/ &
+data h_sa%variable_name, &
+     h_sa%computation_accuracy, &
+     h_sa%values / &
+  "h_SA", 2.3732e-10_r8, &
   -0._r8, -0.0703444245252_r8, -0.140690980113_r8, -0.211015989962_r8, &
   -0.281357361579_r8, -0.351724780023_r8, -0.535243154846_r8, &
   -0.713009174108_r8, -0.892943868807_r8, -1.07624312914_r8, &
@@ -4247,12 +4409,14 @@ data h_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_ct
 
-data h_ct / gsw_result( &
-  "h_CT", 3.1741e-10_r8, (/ &
+data h_ct%variable_name, &
+     h_ct%computation_accuracy, &
+     h_ct%values / &
+  "h_CT", 3.1741e-10_r8, &
   3991.86795711963_r8, 3991.899109148192_r8, 3991.930197377962_r8, &
   3991.961343996476_r8, 3991.992314745479_r8, 3992.023101906704_r8, &
   3992.099382103533_r8, 3992.164886984026_r8, 3992.218843420379_r8, &
@@ -4291,12 +4455,14 @@ data h_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa_sa
 
-data h_sa_sa / gsw_result( &
-  "h_SA_SA", 6.9146e-13_r8, (/ &
+data h_sa_sa%variable_name, &
+     h_sa_sa%computation_accuracy, &
+     h_sa_sa%values / &
+  "h_SA_SA", 6.9146e-13_r8, &
   0._r8, 8.1397526382069e-05_r8, 0.00016282088545724_r8, &
   0.00024416964286206_r8, 0.0003256106759347_r8, 0.00040717897221163_r8, &
   0.00062203535285597_r8, 0.00083569228649105_r8, 0.0010619098317105_r8, &
@@ -4334,12 +4500,14 @@ data h_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa_ct
 
-data h_sa_ct / gsw_result( &
-  "h_SA_CT", 2.2971e-12_r8, (/ &
+data h_sa_ct%variable_name, &
+     h_sa_ct%computation_accuracy, &
+     h_sa_ct%values / &
+  "h_SA_CT", 2.2971e-12_r8, &
   0._r8, 0.00013235155845024_r8, 0.00026491788177432_r8, &
   0.0003972000465178_r8, 0.00053015311342368_r8, 0.00066381937927289_r8, &
   0.0010271783761263_r8, 0.0014130686536778_r8, 0.0018611667326179_r8, &
@@ -4377,12 +4545,14 @@ data h_sa_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_ct_ct
 
-data h_ct_ct / gsw_result( &
-  "h_CT_CT", 1.111e-11_r8, (/ &
+data h_ct_ct%variable_name, &
+     h_ct_ct%computation_accuracy, &
+     h_ct_ct%values / &
+  "h_CT_CT", 1.111e-11_r8, &
   0._r8, 0.00072370638757511_r8, 0.0014481147400949_r8, &
   0.0021713197701715_r8, 0.0028968481383241_r8, 0.0036249402798941_r8, &
   0.0055722870733224_r8, 0.0075569109188247_r8, 0.0097087336310178_r8, &
@@ -4420,12 +4590,14 @@ data h_ct_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_sa
 
-data ct_sa / gsw_result( &
-  "CT_SA", 1.0062e-12_r8, (/ &
+data ct_sa%variable_name, &
+     ct_sa%computation_accuracy, &
+     ct_sa%values / &
+  "CT_SA", 1.0062e-12_r8, &
   -0.0409833106342_r8, -0.040981657685_r8, -0.0409220221954_r8, &
   -0.0409289788576_r8, -0.0408533232719_r8, -0.040745170869_r8, &
   -0.0397520455331_r8, -0.0379932800899_r8, -0.0354768140836_r8, &
@@ -4464,12 +4636,14 @@ data ct_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_pt
 
-data ct_pt / gsw_result( &
-  "CT_pt", 2.9643e-13_r8, (/ &
+data ct_pt%variable_name, &
+     ct_pt%computation_accuracy, &
+     ct_pt%values / &
+  "CT_pt", 2.9643e-13_r8, &
   1.002958538576044_r8, 1.002958941179812_r8, 1.002959035423763_r8, &
   1.002956628419809_r8, 1.002917125345774_r8, 1.00289764618034_r8, &
   1.002553017765266_r8, 1.002055543529764_r8, 1.001612650133013_r8, &
@@ -4508,12 +4682,14 @@ data ct_pt / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_sa_sa
 
-data ct_sa_sa / gsw_result( &
-  "CT_SA_SA", 1.4311e-14_r8, (/ &
+data ct_sa_sa%variable_name, &
+     ct_sa_sa%computation_accuracy, &
+     ct_sa_sa%values / &
+  "CT_SA_SA", 1.4311e-14_r8, &
   -6.36878576718e-05_r8, -6.36927715328e-05_r8, -6.38743953078e-05_r8, &
   -6.38539027523e-05_r8, -6.40960964028e-05_r8, -6.44319069003e-05_r8, &
   -6.75834092337e-05_r8, -7.32357228752e-05_r8, -8.15403612966e-05_r8, &
@@ -4552,12 +4728,14 @@ data ct_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_sa_pt
 
-data ct_sa_pt / gsw_result( &
-  "CT_SA_pt", 1.4572e-14_r8, (/ &
+data ct_sa_pt%variable_name, &
+     ct_sa_pt%computation_accuracy, &
+     ct_sa_pt%values / &
+  "CT_SA_pt", 1.4572e-14_r8, &
   -0.001201729901071_r8, -0.0012017376744939_r8, -0.0012019771449474_r8, &
   -0.0012019423143274_r8, -0.0012021333798387_r8, -0.0012025141567314_r8, &
   -0.0012056259620472_r8, -0.0012118811172112_r8, -0.0012226346776453_r8, &
@@ -4596,12 +4774,14 @@ data ct_sa_pt / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_pt_pt
 
-data ct_pt_pt / gsw_result( &
-  "CT_pt_pt", 5.5511e-14_r8, (/ &
+data ct_pt_pt%variable_name, &
+     ct_pt_pt%computation_accuracy, &
+     ct_pt_pt%values / &
+  "CT_pt_pt", 5.5511e-14_r8, &
   0.000124111537847_r8, 0.000124112731492_r8, 0.000124210668895_r8, &
   0.000124208357588_r8, 0.000124484183051_r8, 0.000124738725149_r8, &
   0.000127795116511_r8, 0.000133057441876_r8, 0.000139702953539_r8, &
@@ -4640,12 +4820,14 @@ data ct_pt_pt / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: eta_sa
 
-data eta_sa / gsw_result( &
-  "eta_SA", 4.6535e-12_r8, (/ &
+data eta_sa%variable_name, &
+     eta_sa%computation_accuracy, &
+     eta_sa%values / &
+  "eta_SA", 4.6535e-12_r8, &
   -0.26024481744639_r8, -0.26023878112853_r8, -0.260110523892_r8, &
   -0.26014033331836_r8, -0.26022323761198_r8, -0.26011269553237_r8, &
   -0.26012725656202_r8, -0.2594833716252_r8, -0.25702700693321_r8, &
@@ -4684,12 +4866,14 @@ data eta_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: eta_ct
 
-data eta_ct / gsw_result( &
-  "eta_CT", 3.1376e-11_r8, (/ &
+data eta_ct%variable_name, &
+     eta_ct%computation_accuracy, &
+     eta_ct%values / &
+  "eta_CT", 3.1376e-11_r8, &
   13.257086921543_r8, 13.257146372642_r8, 13.259319253783_r8, &
   13.25907040666_r8, 13.261904312328_r8, 13.2658848561_r8, 13.30282987942_r8, &
   13.368309650579_r8, 13.461893968637_r8, 13.587328864815_r8, &
@@ -4727,12 +4911,14 @@ data eta_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: eta_sa_sa
 
-data eta_sa_sa / gsw_result( &
-  "eta_SA_SA", 6.9959e-13_r8, (/ &
+data eta_sa_sa%variable_name, &
+     eta_sa_sa%computation_accuracy, &
+     eta_sa_sa%values / &
+  "eta_SA_SA", 6.9959e-13_r8, &
   -0.0076606993719205_r8, -0.0076607801120426_r8, -0.0076614314661349_r8, &
   -0.007660979908159_r8, -0.0076556016423327_r8, -0.0076537101763022_r8, &
   -0.0076108544746285_r8, -0.0075539552227363_r8, -0.0075152041413028_r8, &
@@ -4771,12 +4957,14 @@ data eta_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: eta_sa_ct
 
-data eta_sa_ct / gsw_result( &
-  "eta_SA_CT", 4.9819e-14_r8, (/ &
+data eta_sa_ct%variable_name, &
+     eta_sa_ct%computation_accuracy, &
+     eta_sa_ct%values / &
+  "eta_SA_CT", 4.9819e-14_r8, &
   -0.00179905358102_r8, -0.001798996434_r8, -0.00179696732085_r8, &
   -0.00179720965407_r8, -0.00179472518103_r8, -0.00179108340896_r8, &
   -0.00175777806136_r8, -0.00169742979163_r8, -0.00160798123016_r8, &
@@ -4815,12 +5003,14 @@ data eta_sa_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: eta_ct_ct
 
-data eta_ct_ct / gsw_result( &
-  "eta_CT_CT", 2.3814e-13_r8, (/ &
+data eta_ct_ct%variable_name, &
+     eta_ct_ct%computation_accuracy, &
+     eta_ct_ct%values / &
+  "eta_CT_CT", 2.3814e-13_r8, &
   -0.043897224337832_r8, -0.043897600429681_r8, -0.043911987346934_r8, &
   -0.043910444487873_r8, -0.043930947039087_r8, -0.043958176410965_r8, &
   -0.044218556247544_r8, -0.044677105730752_r8, -0.045324848684811_r8, &
@@ -4859,12 +5049,14 @@ data eta_ct_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_sa
 
-data pt_sa / gsw_result( &
-  "pt_SA", 9.6705e-13_r8, (/ &
+data pt_sa%variable_name, &
+     pt_sa%computation_accuracy, &
+     pt_sa%values / &
+  "pt_SA", 9.6705e-13_r8, &
   0.040862417595445_r8, 0.04086075311991_r8, 0.040801289733733_r8, &
   0.04080832380764_r8, 0.040734495642218_r8, 0.040627446902701_r8, &
   0.039650816294649_r8, 0.037915343450963_r8, 0.035419694508532_r8, &
@@ -4903,12 +5095,14 @@ data pt_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_ct
 
-data pt_ct / gsw_result( &
-  "pt_CT", 2.7334e-13_r8, (/ &
+data pt_ct%variable_name, &
+     pt_ct%computation_accuracy, &
+     pt_ct%values / &
+  "pt_CT", 2.7334e-13_r8, &
   0.9970501885549081_r8, 0.9970497883230083_r8, 0.9970496946343255_r8, &
   0.9970520874621792_r8, 0.9970913595230831_r8, 0.9971107259136801_r8, &
   0.9974534835365053_r8, 0.9979486730620505_r8, 0.9983899463202677_r8, &
@@ -4947,12 +5141,14 @@ data pt_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_sa_sa
 
-data pt_sa_sa / gsw_result( &
-  "pt_SA_SA", 1.7347e-14_r8, (/ &
+data pt_sa_sa%variable_name, &
+     pt_sa_sa%computation_accuracy, &
+     pt_sa_sa%values / &
+  "pt_SA_SA", 1.7347e-14_r8, &
   0.00016121484144908_r8, 0.00016121633563233_r8, 0.00016127483338065_r8, &
   0.00016126874639556_r8, 0.00016135543935046_r8, 0.00016146829623402_r8, &
   0.00016257553986414_r8, 0.00016460386981953_r8, 0.00016770533940763_r8, &
@@ -4991,12 +5187,14 @@ data pt_sa_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_sa_ct
 
-data pt_sa_ct / gsw_result( &
-  "pt_SA_CT", 1.1991e-14_r8, (/ &
+data pt_sa_ct%variable_name, &
+     pt_sa_ct%computation_accuracy, &
+     pt_sa_ct%values / &
+  "pt_SA_CT", 1.1991e-14_r8, &
   0.0011896089830878_r8, 0.0011896159125316_r8, 0.0011898571127334_r8, &
   0.0011898274234723_r8, 0.0011901090576876_r8, 0.0011905368358324_r8, &
   0.0011944520815229_r8, 0.001201890045969_r8, 0.0012137685175098_r8, &
@@ -5035,12 +5233,14 @@ data pt_sa_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pt_ct_ct
 
-data pt_ct_ct / gsw_result( &
-  "pt_CT_CT", 4.4409e-14_r8, (/ &
+data pt_ct_ct%variable_name, &
+     pt_ct_ct%computation_accuracy, &
+     pt_ct_ct%values / &
+  "pt_CT_CT", 4.4409e-14_r8, &
   -0.000123016457615_r8, -0.000123017492609_r8, -0.000123114531048_r8, &
   -0.000123113126504_r8, -0.000123401100305_r8, -0.000123660633_r8, &
   -0.000126821303487_r8, -0.000132240287515_r8, -0.000139029251694_r8, &
@@ -5079,12 +5279,14 @@ data pt_ct_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_freezing
 
-data ct_freezing / gsw_result( &
-  "CT_freezing", 2.2651e-11_r8, (/ &
+data ct_freezing%variable_name, &
+     ct_freezing%computation_accuracy, &
+     ct_freezing%values / &
+  "CT_freezing", 2.2651e-11_r8, &
   -1.8791958949408_r8, -1.8868182053422_r8, -1.8941709221796_r8, &
   -1.9019789045974_r8, -1.9111648742909_r8, -1.9192282573065_r8, &
   -1.9507388874847_r8, -1.9846958607985_r8, -2.0115939142263_r8, &
@@ -5123,12 +5325,14 @@ data ct_freezing / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_freezing_poly
 
-data ct_freezing_poly / gsw_result( &
-  "CT_freezing_poly", 2.2571e-11_r8, (/ &
+data ct_freezing_poly%variable_name, &
+     ct_freezing_poly%computation_accuracy, &
+     ct_freezing_poly%values / &
+  "CT_freezing_poly", 2.2571e-11_r8, &
   -1.879165299189_r8, -1.8867915277169_r8, -1.8941481125296_r8, &
   -1.9019599274485_r8, -1.911149705101_r8, -1.9192168306304_r8, &
   -1.9507370581506_r8, -1.9847028855903_r8, -2.0116093878303_r8, &
@@ -5167,12 +5371,14 @@ data ct_freezing_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: t_freezing
 
-data t_freezing / gsw_result( &
-  "t_freezing", 2.1665e-11_r8, (/ &
+data t_freezing%variable_name, &
+     t_freezing%computation_accuracy, &
+     t_freezing%values / &
+  "t_freezing", 2.1665e-11_r8, &
   -1.8826905931951_r8, -1.8901461677747_r8, -1.8973379624874_r8, &
   -1.9049737446842_r8, -1.9139542679789_r8, -1.9218381661121_r8, &
   -1.9526256815874_r8, -1.9857887399157_r8, -2.0120573882085_r8, &
@@ -5211,12 +5417,14 @@ data t_freezing / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: t_freezing_poly
 
-data t_freezing_poly / gsw_result( &
-  "t_freezing_poly", 2.1582e-11_r8, (/ &
+data t_freezing_poly%variable_name, &
+     t_freezing_poly%computation_accuracy, &
+     t_freezing_poly%values / &
+  "t_freezing_poly", 2.1582e-11_r8, &
   -1.8826599878942_r8, -1.8901194793719_r8, -1.8973151416915_r8, &
   -1.9049547564308_r8, -1.9139390879013_r8, -1.9218267300584_r8, &
   -1.9526238497569_r8, -1.985795778632_r8, -2.0120728991556_r8, &
@@ -5255,12 +5463,14 @@ data t_freezing_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing
 
-data pot_enthalpy_ice_freezing / gsw_result( &
-  "pot_enthalpy_ice_freezing", 5.3551e-08_r8, (/ &
+data pot_enthalpy_ice_freezing%variable_name, &
+     pot_enthalpy_ice_freezing%computation_accuracy, &
+     pot_enthalpy_ice_freezing%values / &
+  "pot_enthalpy_ice_freezing", 5.3551e-08_r8, &
   -337292.5286083188_r8, -337312.7579547644_r8, -337332.4363577975_r8, &
   -337353.038040561_r8, -337376.4389086334_r8, -337397.5541162898_r8, &
   -337473.8724052532_r8, -337554.6512174989_r8, -337621.0606094321_r8, &
@@ -5299,12 +5509,14 @@ data pot_enthalpy_ice_freezing / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing_poly
 
-data pot_enthalpy_ice_freezing_poly / gsw_result( &
-  "pot_enthalpy_ice_freezing_poly", 5.3318e-08_r8, (/ &
+data pot_enthalpy_ice_freezing_poly%variable_name, &
+     pot_enthalpy_ice_freezing_poly%computation_accuracy, &
+     pot_enthalpy_ice_freezing_poly%values / &
+  "pot_enthalpy_ice_freezing_poly", 5.3318e-08_r8, &
   -337292.6233524391_r8, -337312.8580831874_r8, -337332.5417696337_r8, &
   -337353.148655121_r8, -337376.5546690344_r8, -337397.6749009112_r8, &
   -337474.0060546685_r8, -337554.7966502972_r8, -337621.2171142157_r8, &
@@ -5343,12 +5555,14 @@ data pot_enthalpy_ice_freezing_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_freezing_from_ct
 
-data sa_freezing_from_ct / gsw_result( &
-  "SA_freezing_from_CT", 1.364e-10_r8, (/ &
+data sa_freezing_from_ct%variable_name, &
+     sa_freezing_from_ct%computation_accuracy, &
+     sa_freezing_from_ct%values / &
+  "SA_freezing_from_CT", 1.364e-10_r8, &
   34.507499465695_r8, 34.507024988455_r8, 34.501848858516_r8, &
   34.504435326018_r8, 34.530643613167_r8, 34.537484086977_r8, &
   34.736078147784_r8, 34.989090287231_r8, 35.12039462339_r8, &
@@ -5387,12 +5601,14 @@ data sa_freezing_from_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_freezing_from_ct_poly
 
-data sa_freezing_from_ct_poly / gsw_result( &
-  "SA_freezing_from_CT_poly", 1.3004e-10_r8, (/ &
+data sa_freezing_from_ct_poly%variable_name, &
+     sa_freezing_from_ct_poly%computation_accuracy, &
+     sa_freezing_from_ct_poly%values / &
+  "SA_freezing_from_CT_poly", 1.3004e-10_r8, &
   34.507499465607_r8, 34.507024988369_r8, 34.501848858425_r8, &
   34.504435325932_r8, 34.530643613079_r8, 34.537484086889_r8, &
   34.736078147695_r8, 34.989090287136_r8, 35.120394623297_r8, &
@@ -5431,12 +5647,14 @@ data sa_freezing_from_ct_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_freezing_from_t
 
-data sa_freezing_from_t / gsw_result( &
-  "SA_freezing_from_t", 1.3474e-10_r8, (/ &
+data sa_freezing_from_t%variable_name, &
+     sa_freezing_from_t%computation_accuracy, &
+     sa_freezing_from_t%values / &
+  "SA_freezing_from_t", 1.3474e-10_r8, &
   34.507499465694_r8, 34.507024988456_r8, 34.501848858513_r8, &
   34.504435326017_r8, 34.530643613166_r8, 34.537484086978_r8, &
   34.736078147785_r8, 34.98909028723_r8, 35.120394623392_r8, &
@@ -5475,12 +5693,14 @@ data sa_freezing_from_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sa_freezing_from_t_poly
 
-data sa_freezing_from_t_poly / gsw_result( &
-  "SA_freezing_from_t_poly", 1.3007e-10_r8, (/ &
+data sa_freezing_from_t_poly%variable_name, &
+     sa_freezing_from_t_poly%computation_accuracy, &
+     sa_freezing_from_t_poly%values / &
+  "SA_freezing_from_t_poly", 1.3007e-10_r8, &
   34.507499465692_r8, 34.507024988454_r8, 34.501848858511_r8, &
   34.504435326018_r8, 34.530643613166_r8, 34.537484086977_r8, &
   34.736078147786_r8, 34.98909028723_r8, 35.120394623393_r8, &
@@ -5518,12 +5738,14 @@ data sa_freezing_from_t_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ctfreezing_sa
 
-data ctfreezing_sa / gsw_result( &
-  "CTfreezing_SA", 3.2634e-14_r8, (/ &
+data ctfreezing_sa%variable_name, &
+     ctfreezing_sa%computation_accuracy, &
+     ctfreezing_sa%values / &
+  "CTfreezing_SA", 3.2634e-14_r8, &
   -0.05814490213410573_r8, -0.05815075695164051_r8, -0.05815542738436928_r8, &
   -0.05816201376122387_r8, -0.0581744580447603_r8, -0.05818206995235999_r8, &
   -0.05824676222710169_r8, -0.05832438675461858_r8, -0.05837159481981246_r8, &
@@ -5562,12 +5784,14 @@ data ctfreezing_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ctfreezing_p
 
-data ctfreezing_p / gsw_result( &
-  "CTfreezing_P", 9.6244e-20_r8, (/ &
+data ctfreezing_p%variable_name, &
+     ctfreezing_p%computation_accuracy, &
+     ctfreezing_p%values / &
+  "CTfreezing_P", 9.6244e-20_r8, &
   -7.6480068092038e-08_r8, -7.6518457514173e-08_r8, -7.6556555881901e-08_r8, &
   -7.6595105116669e-08_r8, -7.6635040414003e-08_r8, -7.6673812803457e-08_r8, &
   -7.6785147469249e-08_r8, -7.6895553809619e-08_r8, -7.69986626822e-08_r8, &
@@ -5606,12 +5830,14 @@ data ctfreezing_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ctfreezing_sa_poly
 
-data ctfreezing_sa_poly / gsw_result( &
-  "CTfreezing_SA_poly", 3.2564e-14_r8, (/ &
+data ctfreezing_sa_poly%variable_name, &
+     ctfreezing_sa_poly%computation_accuracy, &
+     ctfreezing_sa_poly%values / &
+  "CTfreezing_SA_poly", 3.2564e-14_r8, &
   -0.05814467152917618_r8, -0.05815038625171885_r8, -0.05815491563437256_r8, &
   -0.05816136541989279_r8, -0.05817368399260965_r8, -0.0581811629021938_r8, &
   -0.05824558332937864_r8, -0.05832296649102838_r8, -0.05836988848874046_r8, &
@@ -5650,12 +5876,14 @@ data ctfreezing_sa_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ctfreezing_p_poly
 
-data ctfreezing_p_poly / gsw_result( &
-  "CTfreezing_P_poly", 9.5424e-20_r8, (/ &
+data ctfreezing_p_poly%variable_name, &
+     ctfreezing_p_poly%computation_accuracy, &
+     ctfreezing_p_poly%values / &
+  "CTfreezing_P_poly", 9.5424e-20_r8, &
   -7.6519219369902e-08_r8, -7.6557158499616e-08_r8, -7.6594815665582e-08_r8, &
   -7.663291556094e-08_r8, -7.6672372042886e-08_r8, -7.6710694882539e-08_r8, &
   -7.6820632618496e-08_r8, -7.6929637076692e-08_r8, -7.7031528924063e-08_r8, &
@@ -5694,12 +5922,14 @@ data ctfreezing_p_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: tfreezing_sa
 
-data tfreezing_sa / gsw_result( &
-  "tfreezing_SA", 2.8484e-14_r8, (/ &
+data tfreezing_sa%variable_name, &
+     tfreezing_sa%computation_accuracy, &
+     tfreezing_sa%values / &
+  "tfreezing_SA", 2.8484e-14_r8, &
   -0.0567798139031856_r8, -0.05678223413923639_r8, -0.05678381518356748_r8, &
   -0.05678678319366636_r8, -0.05679397565929661_r8, -0.0567977086108083_r8, &
   -0.05683986295353308_r8, -0.0568917809875421_r8, -0.05692190838769959_r8, &
@@ -5738,12 +5968,14 @@ data tfreezing_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: tfreezing_p
 
-data tfreezing_p / gsw_result( &
-  "tfreezing_P", 7.3771e-20_r8, (/ &
+data tfreezing_p%variable_name, &
+     tfreezing_p%computation_accuracy, &
+     tfreezing_p%values / &
+  "tfreezing_P", 7.3771e-20_r8, &
   -7.480941459441868e-08_r8, -7.484142543119165e-08_r8, &
   -7.487331343513785e-08_r8, -7.490539089547e-08_r8, &
   -7.493805577390966e-08_r8, -7.497023025286e-08_r8, &
@@ -5798,12 +6030,14 @@ data tfreezing_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: tfreezing_sa_poly
 
-data tfreezing_sa_poly / gsw_result( &
-  "tfreezing_SA_poly", 2.8491e-14_r8, (/ &
+data tfreezing_sa_poly%variable_name, &
+     tfreezing_sa_poly%computation_accuracy, &
+     tfreezing_sa_poly%values / &
+  "tfreezing_SA_poly", 2.8491e-14_r8, &
   -0.05677829479024063_r8, -0.0567807670382359_r8, -0.05678240120546947_r8, &
   -0.05678541898982356_r8, -0.05679265212180497_r8, -0.05679643211457153_r8, &
   -0.05683864055310561_r8, -0.05689058494300873_r8, -0.05692077819438569_r8, &
@@ -5842,12 +6076,14 @@ data tfreezing_sa_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: tfreezing_p_poly
 
-data tfreezing_p_poly / gsw_result( &
-  "tfreezing_P_poly", 7.2183e-20_r8, (/ &
+data tfreezing_p_poly%variable_name, &
+     tfreezing_p_poly%computation_accuracy, &
+     tfreezing_p_poly%values / &
+  "tfreezing_P_poly", 7.2183e-20_r8, &
   -7.48621143377235e-08_r8, -7.489348575458774e-08_r8, &
   -7.492473540464642e-08_r8, -7.495618195749665e-08_r8, &
   -7.498823116402291e-08_r8, -7.501978353580322e-08_r8, &
@@ -5902,12 +6138,14 @@ data tfreezing_p_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing_sa
 
-data pot_enthalpy_ice_freezing_sa / gsw_result( &
-  "pot_enthalpy_ice_freezing_SA", 5.447e-11_r8, (/ &
+data pot_enthalpy_ice_freezing_sa%variable_name, &
+     pot_enthalpy_ice_freezing_sa%computation_accuracy, &
+     pot_enthalpy_ice_freezing_sa%values / &
+  "pot_enthalpy_ice_freezing_SA", 5.447e-11_r8, &
   -118.2770096024129_r8, -118.2770858177355_r8, -118.2755244900544_r8, &
   -118.2766657809087_r8, -118.2860412973467_r8, -118.2886706672191_r8, &
   -118.3587579103741_r8, -118.448335109222_r8, -118.495416784849_r8, &
@@ -5946,12 +6184,14 @@ data pot_enthalpy_ice_freezing_sa / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing_p
 
-data pot_enthalpy_ice_freezing_p / gsw_result( &
-  "pot_enthalpy_ice_freezing_P", 1.1905e-16_r8, (/ &
+data pot_enthalpy_ice_freezing_p%variable_name, &
+     pot_enthalpy_ice_freezing_p%computation_accuracy, &
+     pot_enthalpy_ice_freezing_p%values / &
+  "pot_enthalpy_ice_freezing_P", 1.1905e-16_r8, &
   -0.0002028289015986082_r8, -0.0002028804196652307_r8, &
   -0.0002029319085347564_r8, -0.0002029833982269374_r8, &
   -0.0002030349272731101_r8, -0.0002030863917016377_r8, &
@@ -6006,12 +6246,14 @@ data pot_enthalpy_ice_freezing_p / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing_sa_poly
 
-data pot_enthalpy_ice_freezing_sa_poly / gsw_result( &
-  "pot_enthalpy_ice_freezing_SA_poly", 5.4158e-11_r8, (/ &
+data pot_enthalpy_ice_freezing_sa_poly%variable_name, &
+     pot_enthalpy_ice_freezing_sa_poly%computation_accuracy, &
+     pot_enthalpy_ice_freezing_sa_poly%values / &
+  "pot_enthalpy_ice_freezing_SA_poly", 5.4158e-11_r8, &
   -118.2786136748115_r8, -118.2786691962934_r8, -118.277093410823_r8, &
   -118.2782095157019_r8, -118.2875281648098_r8, -118.2901267940559_r8, &
   -118.3599003949369_r8, -118.4491097058922_r8, -118.4959866045523_r8, &
@@ -6050,12 +6292,14 @@ data pot_enthalpy_ice_freezing_sa_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_enthalpy_ice_freezing_p_poly
 
-data pot_enthalpy_ice_freezing_p_poly / gsw_result( &
-  "pot_enthalpy_ice_freezing_P_poly", 1.1636e-16_r8, (/ &
+data pot_enthalpy_ice_freezing_p_poly%variable_name, &
+     pot_enthalpy_ice_freezing_p_poly%computation_accuracy, &
+     pot_enthalpy_ice_freezing_p_poly%values / &
+  "pot_enthalpy_ice_freezing_P_poly", 1.1636e-16_r8, &
   -0.0002028832220404636_r8, -0.0002029338014859178_r8, &
   -0.0002029843592261198_r8, -0.0002030349225727318_r8, &
   -0.000203085526573594_r8, -0.000203136076554657_r8, &
@@ -6110,12 +6354,14 @@ data pot_enthalpy_ice_freezing_p_poly / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: latentheat_melting
 
-data latentheat_melting / gsw_result( &
-  "latentheat_melting", 6.3214e-08_r8, (/ &
+data latentheat_melting%variable_name, &
+     latentheat_melting%computation_accuracy, &
+     latentheat_melting%values / &
+  "latentheat_melting", 6.3214e-08_r8, &
   329985.5184172138_r8, 329967.4069665318_r8, 329949.6870640397_r8, &
   329931.2780902656_r8, 329910.8047362334_r8, 329891.9944452619_r8, &
   329827.3410740866_r8, 329759.7153231357_r8, 329702.5300849362_r8, &
@@ -6154,12 +6400,14 @@ data latentheat_melting / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: latentheat_evap_ct
 
-data latentheat_evap_ct / gsw_result( &
-  "latentheat_evap_CT", 1.4557e-06_r8, (/ &
+data latentheat_evap_ct%variable_name, &
+     latentheat_evap_ct%computation_accuracy, &
+     latentheat_evap_ct%values / &
+  "latentheat_evap_CT", 1.4557e-06_r8, &
   2431864.952769883_r8, 2431868.202103747_r8, 2431986.861042973_r8, &
   2431973.261047543_r8, 2432127.743472645_r8, 2432344.798548297_r8, &
   2434351.343116321_r8, 2437877.091674121_r8, 2442850.427368078_r8, &
@@ -6198,12 +6446,14 @@ data latentheat_evap_ct / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: latentheat_evap_t
 
-data latentheat_evap_t / gsw_result( &
-  "latentheat_evap_t", 1.4431e-06_r8, (/ &
+data latentheat_evap_t%variable_name, &
+     latentheat_evap_t%computation_accuracy, &
+     latentheat_evap_t%values / &
+  "latentheat_evap_t", 1.4431e-06_r8, &
   2431864.952769883_r8, 2431862.551762854_r8, 2431975.574268352_r8, &
   2431956.325670936_r8, 2432105.197918318_r8, 2432316.682174483_r8, &
   2434309.552635047_r8, 2437823.807558516_r8, 2442788.011152495_r8, &
@@ -6242,12 +6492,14 @@ data latentheat_evap_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: grav
 
-data grav / gsw_result( &
-  "grav", 5.3291e-14_r8, (/ &
+data grav%variable_name, &
+     grav%computation_accuracy, &
+     grav%values / &
+  "grav", 5.3291e-14_r8, &
   9.782207133388146_r8, 9.782229115001646_r8, 9.782251095547741_r8, &
   9.782273075026763_r8, 9.782295053439038_r8, 9.782317030784899_r8, &
   9.782374166895663_r8, 9.782429098672781_r8, 9.782484023797332_r8, &
@@ -6286,12 +6538,14 @@ data grav / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: enthalpy_ct_exact
 
-data enthalpy_ct_exact / gsw_result( &
-  "enthalpy_CT_exact", 2.4993e-06_r8, (/ &
+data enthalpy_ct_exact%variable_name, &
+     enthalpy_ct_exact%computation_accuracy, &
+     enthalpy_ct_exact%values / &
+  "enthalpy_CT_exact", 2.4993e-06_r8, &
   111751.65419162_r8, 111844.17892919_r8, 111745.31155707_r8, &
   111865.3552419_r8, 111701.33349996_r8, 111436.44754759_r8, &
   108313.46433704_r8, 102637.16898192_r8, 94559.551909165_r8, &
@@ -6330,12 +6584,14 @@ data enthalpy_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa_ct_exact
 
-data h_sa_ct_exact / gsw_result( &
-  "h_SA_CT_exact", 2.3714e-10_r8, (/ &
+data h_sa_ct_exact%variable_name, &
+     h_sa_ct_exact%computation_accuracy, &
+     h_sa_ct_exact%values / &
+  "h_SA_CT_exact", 2.3714e-10_r8, &
   0._r8, -0.0703453379025_r8, -0.140692842553_r8, -0.211018738227_r8, &
   -0.28136087909_r8, -0.351729215062_r8, -0.535248658826_r8, &
   -0.713014572037_r8, -0.892951458055_r8, -1.07625661092_r8, &
@@ -6367,12 +6623,14 @@ data h_sa_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_ct_ct_exact
 
-data h_ct_ct_exact / gsw_result( &
-  "h_CT_CT_exact", 3.1605e-10_r8, (/ &
+data h_ct_ct_exact%variable_name, &
+     h_ct_ct_exact%computation_accuracy, &
+     h_ct_ct_exact%values / &
+  "h_CT_CT_exact", 3.1605e-10_r8, &
   3991.86795711963_r8, 3991.899115705432_r8, 3991.930210459405_r8, &
   3991.961363614644_r8, 3991.992340862369_r8, 3992.023134437034_r8, &
   3992.099429834566_r8, 3992.164942642608_r8, 3992.218889657059_r8, &
@@ -6411,12 +6669,14 @@ data h_ct_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa_sa_ct_exact
 
-data h_sa_sa_ct_exact / gsw_result( &
-  "h_SA_SA_CT_exact", 7.2642e-13_r8, (/ &
+data h_sa_sa_ct_exact%variable_name, &
+     h_sa_sa_ct_exact%computation_accuracy, &
+     h_sa_sa_ct_exact%values / &
+  "h_SA_SA_CT_exact", 7.2642e-13_r8, &
   0._r8, 8.3293771940984e-05_r8, 0.00016661627683259_r8, &
   0.00024985471597921_r8, 0.00033322864885257_r8, 0.00041674434162694_r8, &
   0.0006374713322103_r8, 0.00085799266620436_r8, 0.0010918055595788_r8, &
@@ -6454,12 +6714,14 @@ data h_sa_sa_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_sa_ct_ct_exact
 
-data h_sa_ct_ct_exact / gsw_result( &
-  "h_SA_CT_CT_exact", 2.1886e-12_r8, (/ &
+data h_sa_ct_ct_exact%variable_name, &
+     h_sa_ct_ct_exact%computation_accuracy, &
+     h_sa_ct_ct_exact%values / &
+  "h_SA_CT_CT_exact", 2.1886e-12_r8, &
   0._r8, 0.00013268757223357_r8, 0.00026558329352477_r8, &
   0.00039818703394291_r8, 0.00053144224710609_r8, 0.00066540649384499_r8, &
   0.0010293060843694_r8, 0.0014153525397819_r8, 0.0018632306307213_r8, &
@@ -6497,12 +6759,14 @@ data h_sa_ct_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: h_ct_ct_ct_exact
 
-data h_ct_ct_ct_exact / gsw_result( &
-  "h_CT_CT_CT_exact", 1.1351e-11_r8, (/ &
+data h_ct_ct_ct_exact%variable_name, &
+     h_ct_ct_ct_exact%computation_accuracy, &
+     h_ct_ct_ct_exact%values / &
+  "h_CT_CT_CT_exact", 1.1351e-11_r8, &
   0._r8, 0.0007239355778385_r8, 0.0014485822042462_r8, 0.0021719997800172_r8, &
   0.0028977880486357_r8, 0.0036261831957023_r8, 0.0055754565807141_r8, &
   0.0075641679358376_r8, 0.0097224372899309_r8, 0.01213376483139_r8, &
@@ -6540,12 +6804,14 @@ data h_ct_ct_ct_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: rho_t_exact
 
-data rho_t_exact / gsw_result( &
-  "rho_t_exact", 2.9445e-10_r8, (/ &
+data rho_t_exact%variable_name, &
+     rho_t_exact%computation_accuracy, &
+     rho_t_exact%values / &
+  "rho_t_exact", 2.9445e-10_r8, &
   1021.915980252376_r8, 1021.95820244202_r8, 1022.012562533378_r8, &
   1022.054777270649_r8, 1022.137480309065_r8, 1022.214133439513_r8, &
   1022.741973341495_r8, 1023.499560650793_r8, 1024.329987849211_r8, &
@@ -6584,12 +6850,14 @@ data rho_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: pot_rho_t_exact
 
-data pot_rho_t_exact / gsw_result( &
-  "pot_rho_t_exact", 2.9297e-10_r8, (/ &
+data pot_rho_t_exact%variable_name, &
+     pot_rho_t_exact%computation_accuracy, &
+     pot_rho_t_exact%values / &
+  "pot_rho_t_exact", 2.9297e-10_r8, &
   1021.915980252376_r8, 1021.916065964516_r8, 1021.928286405551_r8, &
   1021.928379495913_r8, 1021.968943563418_r8, 1022.003433190205_r8, &
   1022.421109956852_r8, 1023.071528441043_r8, 1023.792722022634_r8, &
@@ -6628,12 +6896,14 @@ data pot_rho_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: alpha_wrt_t_exact
 
-data alpha_wrt_t_exact / gsw_result( &
-  "alpha_wrt_t_exact", 8.5949e-15_r8, (/ &
+data alpha_wrt_t_exact%variable_name, &
+     alpha_wrt_t_exact%computation_accuracy, &
+     alpha_wrt_t_exact%values / &
+  "alpha_wrt_t_exact", 8.5949e-15_r8, &
   0.00031932154689476_r8, 0.00031939555594613_r8, 0.00031911127821026_r8, &
   0.00031923984048154_r8, 0.00031887380972951_r8, 0.00031829851431434_r8, &
   0.00031250507120278_r8, 0.00030189699151599_r8, 0.00028623167442661_r8, &
@@ -6672,12 +6942,14 @@ data alpha_wrt_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: beta_const_t_exact
 
-data beta_const_t_exact / gsw_result( &
-  "beta_const_t_exact", 1.8049e-15_r8, (/ &
+data beta_const_t_exact%variable_name, &
+     beta_const_t_exact%computation_accuracy, &
+     beta_const_t_exact%values / &
+  "beta_const_t_exact", 1.8049e-15_r8, &
   0.00073197647430931_r8, 0.00073189381057819_r8, 0.00073185563197511_r8, &
   0.00073176606119531_r8, 0.00073173538343879_r8, 0.00073173225731012_r8, &
   0.00073224704776871_r8, 0.00073340593192962_r8, 0.00073532885276884_r8, &
@@ -6716,12 +6988,14 @@ data beta_const_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: specvol_t_exact
 
-data specvol_t_exact / gsw_result( &
-  "specvol_t_exact", 2.8189e-16_r8, (/ &
+data specvol_t_exact%variable_name, &
+     specvol_t_exact%computation_accuracy, &
+     specvol_t_exact%values / &
+  "specvol_t_exact", 2.8189e-16_r8, &
   0.0009785540292197368_r8, 0.0009785136002729369_r8, &
   0.0009784615538591687_r8, 0.0009784211396873022_r8, &
   0.0009783419738190488_r8, 0.0009782686105456522_r8, &
@@ -6774,12 +7048,14 @@ data specvol_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: sound_speed_t_exact
 
-data sound_speed_t_exact / gsw_result( &
-  "sound_speed_t_exact", 2.5902e-09_r8, (/ &
+data sound_speed_t_exact%variable_name, &
+     sound_speed_t_exact%computation_accuracy, &
+     sound_speed_t_exact%values / &
+  "sound_speed_t_exact", 2.5902e-09_r8, &
   1540.4511400817_r8, 1540.6174829909_r8, 1540.6733946822_r8, &
   1540.8583527734_r8, 1540.914104975_r8, 1540.8918342152_r8, &
   1539.6737875821_r8, 1536.9672850869_r8, 1532.4751224261_r8, &
@@ -6818,12 +7094,14 @@ data sound_speed_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: kappa_t_exact
 
-data kappa_t_exact / gsw_result( &
-  "kappa_t_exact", 1.7127e-21_r8, (/ &
+data kappa_t_exact%variable_name, &
+     kappa_t_exact%computation_accuracy, &
+     kappa_t_exact%values / &
+  "kappa_t_exact", 1.7127e-21_r8, &
   4.1237179539499e-10_r8, 4.1226571787447e-10_r8, 4.1221386930498e-10_r8, &
   4.1209789253237e-10_r8, 4.1203473144474e-10_r8, 4.120157436542e-10_r8, &
   4.1245491953047e-10_r8, 4.1360244028808e-10_r8, 4.1569351243739e-10_r8, &
@@ -6862,12 +7140,14 @@ data kappa_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: enthalpy_t_exact
 
-data enthalpy_t_exact / gsw_result( &
-  "enthalpy_t_exact", 2.4993e-06_r8, (/ &
+data enthalpy_t_exact%variable_name, &
+     enthalpy_t_exact%computation_accuracy, &
+     enthalpy_t_exact%values / &
+  "enthalpy_t_exact", 2.4993e-06_r8, &
   111751.65419162_r8, 111844.17892919_r8, 111745.31155707_r8, &
   111865.3552419_r8, 111701.33349996_r8, 111436.44754759_r8, &
   108313.46433704_r8, 102637.16898192_r8, 94559.551909165_r8, &
@@ -6906,12 +7186,14 @@ data enthalpy_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_sa_wrt_t
 
-data ct_sa_wrt_t / gsw_result( &
-  "CT_SA_wrt_t", 1.0223e-12_r8, (/ &
+data ct_sa_wrt_t%variable_name, &
+     ct_sa_wrt_t%computation_accuracy, &
+     ct_sa_wrt_t%values / &
+  "CT_SA_wrt_t", 1.0223e-12_r8, &
   -0.0409833106342_r8, -0.0409894510556_r8, -0.0409376254811_r8, &
   -0.0409523700556_r8, -0.0408845525164_r8, -0.0407842933687_r8, &
   -0.0398128856157_r8, -0.0380777753711_r8, -0.0355896901211_r8, &
@@ -6950,12 +7232,14 @@ data ct_sa_wrt_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_t_wrt_t
 
-data ct_t_wrt_t / gsw_result( &
-  "CT_T_wrt_t", 6.2705e-13_r8, (/ &
+data ct_t_wrt_t%variable_name, &
+     ct_t_wrt_t%computation_accuracy, &
+     ct_t_wrt_t%values / &
+  "CT_T_wrt_t", 6.2705e-13_r8, &
   1.002958538576044_r8, 1.002896185663372_r8, 1.002833512323822_r8, &
   1.002768412900711_r8, 1.002666156643026_r8, 1.002583825491344_r8, &
   1.002073851937162_r8, 1.001413248070416_r8, 1.000800704852227_r8, &
@@ -6994,12 +7278,14 @@ data ct_t_wrt_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: ct_p_wrt_t
 
-data ct_p_wrt_t / gsw_result( &
-  "CT_P_wrt_t", 6.1712e-19_r8, (/ &
+data ct_p_wrt_t%variable_name, &
+     ct_p_wrt_t%computation_accuracy, &
+     ct_p_wrt_t%values / &
+  "CT_P_wrt_t", 6.1712e-19_r8, &
   -2.35702902289e-08_r8, -2.35746733554e-08_r8, -2.35485782607e-08_r8, &
   -2.35575345011e-08_r8, -2.35235924693e-08_r8, -2.34723464522e-08_r8, &
   -2.29692572777e-08_r8, -2.20645273137e-08_r8, -2.07573371066e-08_r8, &
@@ -7038,12 +7324,14 @@ data ct_p_wrt_t / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: chem_potential_water_t_exact
 
-data chem_potential_water_t_exact / gsw_result( &
-  "chem_potential_water_t_exact", 4.8118e-10_r8, (/ &
+data chem_potential_water_t_exact%variable_name, &
+     chem_potential_water_t_exact%computation_accuracy, &
+     chem_potential_water_t_exact%values / &
+  "chem_potential_water_t_exact", 4.8118e-10_r8, &
   -8.2813019097643_r8, -8.1813570058991_r8, -8.0610290757152_r8, &
   -7.9642520846518_r8, -7.8401963043867_r8, -7.7038894634784_r8, &
   -7.1194196809707_r8, -6.3130352258349_r8, -5.3098624806101_r8, &
@@ -7082,12 +7370,14 @@ data chem_potential_water_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: t_deriv_chem_potential_water_t_exact
 
-data t_deriv_chem_potential_water_t_exact / gsw_result( &
-  "t_deriv_chem_potential_water_t_exact", 9.1325e-12_r8, (/ &
+data t_deriv_chem_potential_water_t_exact%variable_name, &
+     t_deriv_chem_potential_water_t_exact%computation_accuracy, &
+     t_deriv_chem_potential_water_t_exact%values / &
+  "t_deriv_chem_potential_water_t_exact", 9.1325e-12_r8, &
   -0.417380847621_r8, -0.417365578057_r8, -0.416684354598_r8, &
   -0.416766918177_r8, -0.415887140889_r8, -0.41464155826_r8, &
   -0.403114772169_r8, -0.382728871345_r8, -0.353695057771_r8, &
@@ -7126,12 +7416,14 @@ data t_deriv_chem_potential_water_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: dilution_coefficient_t_exact
 
-data dilution_coefficient_t_exact / gsw_result( &
-  "dilution_coefficient_t_exact", 2.0061e-10_r8, (/ &
+data dilution_coefficient_t_exact%variable_name, &
+     dilution_coefficient_t_exact%computation_accuracy, &
+     dilution_coefficient_t_exact%values / &
+  "dilution_coefficient_t_exact", 2.0061e-10_r8, &
   78.833320052832_r8, 78.83593293107_r8, 78.823088765264_r8, &
   78.828707627146_r8, 78.82145115118_r8, 78.800473970403_r8, &
   78.627440586818_r8, 78.282228915059_r8, 77.712325060703_r8, &
@@ -7170,12 +7462,14 @@ data dilution_coefficient_t_exact / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: deltasa_atlas
 
-data deltasa_atlas / gsw_result( &
-  "deltaSA_atlas", 6.9455e-13_r8, (/ &
+data deltasa_atlas%variable_name, &
+     deltasa_atlas%computation_accuracy, &
+     deltasa_atlas%values / &
+  "deltaSA_atlas", 6.9455e-13_r8, &
   0.00017939635663096_r8, 0.00018024758715744_r8, 0.00018145414888945_r8, &
   0.00018480149666306_r8, 0.0001890819429285_r8, 0.00019257785168297_r8, &
   0.00021838682262078_r8, 0.0002769048901837_r8, 0.0003841754706041_r8, &
@@ -7212,12 +7506,14 @@ data deltasa_atlas / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: fdelta
 
-data fdelta / gsw_result( &
-  "Fdelta", 2.7029e-14_r8, (/ &
+data fdelta%variable_name, &
+     fdelta%computation_accuracy, &
+     fdelta%values / &
+  "Fdelta", 2.7029e-14_r8, &
   7.0162092855842e-06_r8, 7.045771655865e-06_r8, 7.0925570787417e-06_r8, &
   7.2228681299504e-06_r8, 7.3856585860477e-06_r8, 7.516523009202e-06_r8, &
   8.4887977309356e-06_r8, 1.0702138779874e-05_r8, 1.479793570398e-05_r8, &
@@ -7254,12 +7550,14 @@ data fdelta / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2
 
-data n2 / gsw_result_mpres( &
-  "n2", 1.5894e-14_r8, (/ &
+data n2%variable_name, &
+     n2%computation_accuracy, &
+     n2%values / &
+  "n2", 1.5894e-14_r8, &
   8.2026964985796e-08_r8, 1.1699772859452e-05_r8, 8.7438092338887e-08_r8, &
   3.8833373834459e-05_r8, 3.3043599666939e-05_r8, 0.00015391835025989_r8, &
   0.00024952146968971_r8, 0.00027722386889469_r8, 0.00029577102803556_r8, &
@@ -7297,12 +7595,14 @@ data n2 / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: p_mid_n2
 
-data p_mid_n2 / gsw_result_mpres( &
-  "p_mid_n2", 2.3e-08_r8, (/ &
+data p_mid_n2%variable_name, &
+     p_mid_n2%computation_accuracy, &
+     p_mid_n2%values / &
+  "p_mid_n2", 2.3e-08_r8, &
   5._r8, 15._r8, 25._r8, 35._r8, 45._r8, 63._r8, 88.5_r8, 113.5_r8, 138.5_r8, &
   163.5_r8, 189._r8, 227._r8, 277.5_r8, 328._r8, 378.5_r8, 454.5_r8, &
   555.5_r8, 656.5_r8, 757.5_r8, 858.5_r8, 959.5_r8, 1060.5_r8, 1162._r8, &
@@ -7321,12 +7621,14 @@ data p_mid_n2 / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: tu
 
-data tu / gsw_result_mpres( &
-  "Tu", 2.191e-08_r8, (/ &
+data tu%variable_name, &
+     tu%computation_accuracy, &
+     tu%values / &
+  "Tu", 2.191e-08_r8, &
   83.7512715531_r8, 58.3454831514_r8, -88.5886471321_r8, 2.92826882605_r8, &
   35.3335360092_r8, 16.7767955292_r8, 23.1453658821_r8, 36.1807645983_r8, &
   45.0628267869_r8, 53.6905299283_r8, 56.7883441369_r8, 56.9326967577_r8, &
@@ -7356,12 +7658,14 @@ data tu / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: rsubrho
 
-data rsubrho / gsw_result_mpres( &
-  "Rsubrho", 1.7097e-08_r8, (/ &
+data rsubrho%variable_name, &
+     rsubrho%computation_accuracy, &
+     rsubrho%values / &
+  "Rsubrho", 1.7097e-08_r8, &
   1.2459175325039_r8, 4.2153481295466_r8, 0.95190936871968_r8, &
   -1.107820226202_r8, -5.8709296665608_r8, -1.863179843003_r8, &
   -2.4932807508948_r8, -6.4452938606987_r8, 911.96381930288_r8, &
@@ -7399,12 +7703,14 @@ data rsubrho / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: p_mid_tursr
 
-data p_mid_tursr / gsw_result_mpres( &
-  "p_mid_TuRsr", 2.3e-08_r8, (/ &
+data p_mid_tursr%variable_name, &
+     p_mid_tursr%computation_accuracy, &
+     p_mid_tursr%values / &
+  "p_mid_TuRsr", 2.3e-08_r8, &
   5._r8, 15._r8, 25._r8, 35._r8, 45._r8, 63._r8, 88.5_r8, 113.5_r8, 138.5_r8, &
   163.5_r8, 189._r8, 227._r8, 277.5_r8, 328._r8, 378.5_r8, 454.5_r8, &
   555.5_r8, 656.5_r8, 757.5_r8, 858.5_r8, 959.5_r8, 1060.5_r8, 1162._r8, &
@@ -7423,12 +7729,14 @@ data p_mid_tursr / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min
 
-data n2min / gsw_result_mpres( &
-  "n2min", 1.6328e-14_r8, (/ &
+data n2min%variable_name, &
+     n2min%computation_accuracy, &
+     n2min%values / &
+  "n2min", 1.6328e-14_r8, &
   8.194346517331e-08_r8, 1.1693792052724e-05_r8, 8.6908546214712e-08_r8, &
   3.8824431193258e-05_r8, 3.3020752923137e-05_r8, 0.00015310139213068_r8, &
   0.00024668867358782_r8, 0.00027105946540631_r8, 0.00028423794269635_r8, &
@@ -7466,12 +7774,14 @@ data n2min / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_pmid
 
-data n2min_pmid / gsw_result_mpres( &
-  "n2min_pmid", 2.3e-08_r8, (/ &
+data n2min_pmid%variable_name, &
+     n2min_pmid%computation_accuracy, &
+     n2min_pmid%values / &
+  "n2min_pmid", 2.3e-08_r8, &
   0._r8, 20._r8, 30._r8, 40._r8, 50._r8, 76._r8, 101._r8, 126._r8, 151._r8, &
   176._r8, 202._r8, 252._r8, 303._r8, 353._r8, 404._r8, 505._r8, 606._r8, &
   707._r8, 808._r8, 909._r8, 1010._r8, 1111._r8, 1213._r8, 1314._r8, &
@@ -7490,12 +7800,14 @@ data n2min_pmid / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_specvol
 
-data n2min_specvol / gsw_result_mpres( &
-  "n2min_specvol", 2.8189e-16_r8, (/ &
+data n2min_specvol%variable_name, &
+     n2min_specvol%computation_accuracy, &
+     n2min_specvol%values / &
+  "n2min_specvol", 2.8189e-16_r8, &
   0.0009785543233027595_r8, 0.0009784618366719601_r8, &
   0.000978421415045363_r8, 0.0009783422466640218_r8, &
   0.0009782688824288848_r8, 0.0009777640332867593_r8, &
@@ -7547,12 +7859,14 @@ data n2min_specvol / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_alpha
 
-data n2min_alpha / gsw_result_mpres( &
-  "n2min_alpha", 8.2511e-15_r8, (/ &
+data n2min_alpha%variable_name, &
+     n2min_alpha%computation_accuracy, &
+     n2min_alpha%values / &
+  "n2min_alpha", 8.2511e-15_r8, &
   0.00031831246465714_r8, 0.00031814275657959_r8, 0.00031829167734161_r8, &
   0.00031795922055419_r8, 0.00031741177706767_r8, 0.00031179395602026_r8, &
   0.00030141362492837_r8, 0.00028596263812853_r8, 0.00026450886155659_r8, &
@@ -7590,12 +7904,14 @@ data n2min_alpha / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_beta
 
-data n2min_beta / gsw_result_mpres( &
-  "n2min_beta", 1.8397e-15_r8, (/ &
+data n2min_beta%variable_name, &
+     n2min_beta%computation_accuracy, &
+     n2min_beta%values / &
+  "n2min_beta", 1.8397e-15_r8, &
   0.00071891860085091_r8, 0.00071881933367617_r8, 0.00071871921576397_r8, &
   0.00071872418757004_r8, 0.00071877529859646_r8, 0.00071982423795744_r8, &
   0.00072192226059341_r8, 0.00072514590519558_r8, 0.00072975281215256_r8, &
@@ -7633,12 +7949,14 @@ data n2min_beta / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_dsa
 
-data n2min_dsa / gsw_result_mpres( &
-  "n2min_dsa", 8.8818e-16_r8, (/ &
+data n2min_dsa%variable_name, &
+     n2min_dsa%computation_accuracy, &
+     n2min_dsa%values / &
+  "n2min_dsa", 8.8818e-16_r8, &
   -0.0004744772376454875_r8, -0.005176129943286867_r8, &
   0.002586467507178725_r8, 0.02620828714793788_r8, 0.006840473811116965_r8, &
   0.1985940608084107_r8, 0.2530121394447065_r8, 0.131304336162323_r8, &
@@ -7677,12 +7995,14 @@ data n2min_dsa / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_dct
 
-data n2min_dct / gsw_result_mpres( &
-  "n2min_dct", 1.724e-12_r8, (/ &
+data n2min_dct%variable_name, &
+     n2min_dct%computation_accuracy, &
+     n2min_dct%values / &
+  "n2min_dct", 1.724e-12_r8, &
   -0.0013348737376226_r8, -0.049278777774731_r8, 0.0055611990517122_r8, &
   -0.065594930625537_r8, -0.090860123210103_r8, -0.84597374485428_r8, &
   -1.4830388043076_r8, -2.0844865998417_r8, -2.7413460849488_r8, &
@@ -7720,12 +8040,14 @@ data n2min_dct / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: n2min_dp
 
-data n2min_dp / gsw_result_mpres( &
-  "n2min_dp", 2.2737e-13_r8, (/ &
+data n2min_dp%variable_name, &
+     n2min_dp%computation_accuracy, &
+     n2min_dp%values / &
+  "n2min_dp", 2.2737e-13_r8, &
   10._r8, 10._r8, 10._r8, 10._r8, 10._r8, 26._r8, 25._r8, 25._r8, 25._r8, &
   25._r8, 26._r8, 50._r8, 51._r8, 50._r8, 51._r8, 101._r8, 101._r8, 101._r8, &
   101._r8, 101._r8, 101._r8, 101._r8, 102._r8, 101._r8, 102._r8, 101._r8, &
@@ -7742,12 +8064,14 @@ data n2min_dp / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: ipvfn2
 
-data ipvfn2 / gsw_result_mpres( &
-  "IPVfN2", 3.4747e-09_r8, (/ &
+data ipvfn2%variable_name, &
+     ipvfn2%computation_accuracy, &
+     ipvfn2%values / &
+  "IPVfN2", 3.4747e-09_r8, &
   0.998915064829_r8, 0.999297107902_r8, 1.02277262967_r8, 0.999605429655_r8, &
   0.998815151264_r8, 0.998889357966_r8, 0.998028321472_r8, 0.996209050884_r8, &
   0.993415543976_r8, 0.988650700453_r8, 0.983220768023_r8, 0.974597457349_r8, &
@@ -7777,12 +8101,14 @@ data ipvfn2 / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_mpres) :: p_mid_ipvfn2
 
-data p_mid_ipvfn2 / gsw_result_mpres( &
-  "p_mid_IPVfN2", 2.3e-08_r8, (/ &
+data p_mid_ipvfn2%variable_name, &
+     p_mid_ipvfn2%computation_accuracy, &
+     p_mid_ipvfn2%values / &
+  "p_mid_IPVfN2", 2.3e-08_r8, &
   5._r8, 15._r8, 25._r8, 35._r8, 45._r8, 63._r8, 88.5_r8, 113.5_r8, 138.5_r8, &
   163.5_r8, 189._r8, 227._r8, 277.5_r8, 328._r8, 378.5_r8, 454.5_r8, &
   555.5_r8, 656.5_r8, 757.5_r8, 858.5_r8, 959.5_r8, 1060.5_r8, 1162._r8, &
@@ -7801,12 +8127,14 @@ data p_mid_ipvfn2 / gsw_result_mpres( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: n2_lowerlimit
 
-data n2_lowerlimit / gsw_result( &
-  "n2_lowerlimit", 1.725e-18_r8, (/ &
+data n2_lowerlimit%variable_name, &
+     n2_lowerlimit%computation_accuracy, &
+     n2_lowerlimit%values / &
+  "n2_lowerlimit", 1.725e-18_r8, &
   1e-07_r8, 9.9253737531188e-08_r8, 9.8514900498007e-08_r8, &
   9.7783415016138e-08_r8, 9.7059207936424e-08_r8, 9.6342206837554e-08_r8, &
   9.4511215491954e-08_r8, 9.279497746644e-08_r8, 9.1121113508756e-08_r8, &
@@ -7845,19 +8173,23 @@ data n2_lowerlimit / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_cast) :: mlp
 
-data mlp / gsw_result_cast( &
-  "mlp", 2.3e-08_r8, (/ &
+data mlp%variable_name, &
+     mlp%computation_accuracy, &
+     mlp%values / &
+  "mlp", 2.3e-08_r8, &
   50._r8, 50._r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: geo_strf_dyn_height
 
-data geo_strf_dyn_height / gsw_result( &
-  "geo_strf_dyn_height", 3.2646e-07_r8, (/ &
+data geo_strf_dyn_height%variable_name, &
+     geo_strf_dyn_height%computation_accuracy, &
+     geo_strf_dyn_height%values / &
+  "geo_strf_dyn_height", 3.2646e-07_r8, &
   0._r8, -0.589583852182_r8, -1.17898875589_r8, -1.76835996825_r8, &
   -2.35629697345_r8, -2.94107494231_r8, -4.41504899203_r8, -5.70371913969_r8, &
   -6.82833809933_r8, -7.77225648508_r8, -8.56194300993_r8, -9.26464935526_r8, &
@@ -7888,12 +8220,14 @@ data geo_strf_dyn_height / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: geo_strf_dyn_height_pc
 
-data geo_strf_dyn_height_pc / gsw_result( &
-  "geo_strf_dyn_height_pc", 4.2179e-08_r8, (/ &
+data geo_strf_dyn_height_pc%variable_name, &
+     geo_strf_dyn_height_pc%computation_accuracy, &
+     geo_strf_dyn_height_pc%values / &
+  "geo_strf_dyn_height_pc", 4.2179e-08_r8, &
   0._r8, -0.29470152206_r8, -0.883871636364_r8, -1.47292133789_r8, &
   -2.06049336665_r8, -2.64493938313_r8, -3.64315019735_r8, -4.95368424359_r8, &
   -6.07569585812_r8, -7.02216247979_r8, -7.81375276812_r8, -8.50314412232_r8, &
@@ -7924,12 +8258,14 @@ data geo_strf_dyn_height_pc / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result) :: geo_strf_dyn_height_pc_p_mid
 
-data geo_strf_dyn_height_pc_p_mid / gsw_result( &
-  "geo_strf_dyn_height_pc_p_mid", 1e-15_r8, (/ &
+data geo_strf_dyn_height_pc_p_mid%variable_name, &
+     geo_strf_dyn_height_pc_p_mid%computation_accuracy, &
+     geo_strf_dyn_height_pc_p_mid%values / &
+  "geo_strf_dyn_height_pc_p_mid", 1e-15_r8, &
   0._r8, 5._r8, 15._r8, 25._r8, 35._r8, 45._r8, 63._r8, 88.5_r8, 113.5_r8, &
   138.5_r8, 163.5_r8, 189._r8, 227._r8, 277.5_r8, 328._r8, 378.5_r8, &
   454.5_r8, 555.5_r8, 656.5_r8, 757.5_r8, 858.5_r8, 959.5_r8, 1060.5_r8, &
@@ -7948,12 +8284,14 @@ data geo_strf_dyn_height_pc_p_mid / gsw_result( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: rho_ice
 
-data rho_ice / gsw_result_ice( &
-  "rho_ice", 1.1221e-10_r8, (/ &
+data rho_ice%variable_name, &
+     rho_ice%computation_accuracy, &
+     rho_ice%values / &
+  "rho_ice", 1.1221e-10_r8, &
   917.0725744920776_r8, 917.056072336695_r8, 917.1013541739903_r8, &
   917.2348189282852_r8, 917.1907519837395_r8, 917.5662845738501_r8, &
   917.3183127245584_r8, 917.2088052553296_r8, 917.6569448140186_r8, &
@@ -7990,12 +8328,14 @@ data rho_ice / gsw_result_ice( &
   919.3558537741848_r8, 919.6428490009646_r8, 920.1626401152499_r8, &
   920.0451812190762_r8, 920.3733778644217_r8, 920.6970030771812_r8, &
   921.1178395359448_r8, 921.661545043789_r8, 921.9452599025518_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: alpha_wrt_t_ice
 
-data alpha_wrt_t_ice / gsw_result_ice( &
-  "alpha_wrt_t_ice", 3.3873e-16_r8, (/ &
+data alpha_wrt_t_ice%variable_name, &
+     alpha_wrt_t_ice%computation_accuracy, &
+     alpha_wrt_t_ice%values / &
+  "alpha_wrt_t_ice", 3.3873e-16_r8, &
   0.00015867502981839_r8, 0.00015874871682068_r8, 0.0001586152330998_r8, &
   0.00015818417045966_r8, 0.00015835147855663_r8, 0.00015709159656146_r8, &
   0.00015798747177663_r8, 0.00015840343834605_r8, 0.00015692565159078_r8, &
@@ -8032,12 +8372,14 @@ data alpha_wrt_t_ice / gsw_result_ice( &
   0.00015420997666824_r8, 0.00015369994215162_r8, 0.00015237325755508_r8, &
   0.00015327207989466_r8, 0.0001526176702292_r8, 0.00015197841779699_r8, &
   0.0001509937269398_r8, 0.00014956502636122_r8, 0.00014905632274574_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: specvol_ice
 
-data specvol_ice / gsw_result_ice( &
-  "specvol_ice", 1.3336e-16_r8, (/ &
+data specvol_ice%variable_name, &
+     specvol_ice%computation_accuracy, &
+     specvol_ice%values / &
+  "specvol_ice", 1.3336e-16_r8, &
   0.001090426240860874_r8, 0.001090445862761653_r8, 0.001090392022047197_r8, &
   0.001090233361581737_r8, 0.001090285742455598_r8, 0.001089839520928382_r8, &
   0.001090134129155087_r8, 0.001090264282538831_r8, 0.001089731849850131_r8, &
@@ -8074,12 +8416,14 @@ data specvol_ice / gsw_result_ice( &
   0.001087718097290348_r8, 0.00108737865040361_r8, 0.001086764400557222_r8, &
   0.001086903143903196_r8, 0.001086515564281465_r8, 0.001086133653805508_r8, &
   0.001085637425612988_r8, 0.001084996987644189_r8, 0.00108466309605594_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pressure_coefficient_ice
 
-data pressure_coefficient_ice / gsw_result_ice( &
-  "pressure_coefficient_ice", 1.5646e-06_r8, (/ &
+data pressure_coefficient_ice%variable_name, &
+     pressure_coefficient_ice%computation_accuracy, &
+     pressure_coefficient_ice%values / &
+  "pressure_coefficient_ice", 1.5646e-06_r8, &
   1352054.4081673_r8, 1352377.9086491_r8, 1351803.1555507_r8, &
   1349928.7960488_r8, 1350664.1532572_r8, 1345110.5151939_r8, &
   1349088.7567804_r8, 1350916.3442238_r8, 1344415.0717808_r8, &
@@ -8116,12 +8460,14 @@ data pressure_coefficient_ice / gsw_result_ice( &
   1333023.2697216_r8, 1330814.5373764_r8, 1324895.2846607_r8, &
   1329010.9475929_r8, 1326124.6616779_r8, 1323289.4887058_r8, &
   1318873.6222536_r8, 1312370.2263364_r8, 1310068.7164959_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: sound_speed_ice
 
-data sound_speed_ice / gsw_result_ice( &
-  "sound_speed_ice", 1.3333e-09_r8, (/ &
+data sound_speed_ice%variable_name, &
+     sound_speed_ice%computation_accuracy, &
+     sound_speed_ice%values / &
+  "sound_speed_ice", 1.3333e-09_r8, &
   3095.703522406592_r8, 3095.419875364491_r8, 3095.922166375146_r8, &
   3097.549896982661_r8, 3096.913649225968_r8, 3101.651154762964_r8, &
   3098.277202345323_r8, 3096.692824235721_r8, 3102.257173176591_r8, &
@@ -8158,12 +8504,14 @@ data sound_speed_ice / gsw_result_ice( &
   3112.028897055726_r8, 3113.879966337284_r8, 3118.92510087816_r8, &
   3115.239284904962_r8, 3117.654289817829_r8, 3120.012960948077_r8, &
   3123.760458335762_r8, 3129.290190566825_r8, 3131.157287837835_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: kappa_ice
 
-data kappa_ice / gsw_result_ice( &
-  "kappa_ice", 1.0713e-22_r8, (/ &
+data kappa_ice%variable_name, &
+     kappa_ice%computation_accuracy, &
+     kappa_ice%values / &
+  "kappa_ice", 1.0713e-22_r8, &
   1.137830501222573e-10_r8, 1.138059518359331e-10_r8, &
   1.137634091037491e-10_r8, 1.136273414534416e-10_r8, &
   1.136794962916872e-10_r8, 1.132861065691551e-10_r8, &
@@ -8216,12 +8564,14 @@ data kappa_ice / gsw_result_ice( &
   1.117186071631419e-10_r8, 1.11997421259374e-10_r8, &
   1.117841016378322e-10_r8, 1.115759194133638e-10_r8, &
   1.112575162073459e-10_r8, 1.107992587479614e-10_r8, 1.106331036227652e-10_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: kappa_const_t_ice
 
-data kappa_const_t_ice / gsw_result_ice( &
-  "kappa_const_t_ice", 1.2219e-22_r8, (/ &
+data kappa_const_t_ice%variable_name, &
+     kappa_const_t_ice%computation_accuracy, &
+     kappa_const_t_ice%values / &
+  "kappa_const_t_ice", 1.2219e-22_r8, &
   1.173584649108e-10_r8, 1.1738487874241e-10_r8, 1.1733604293533e-10_r8, &
   1.1717964008373e-10_r8, 1.1723971364366e-10_r8, 1.1678712996962e-10_r8, &
   1.1710680337569e-10_r8, 1.1725628979422e-10_r8, 1.1672410915694e-10_r8, &
@@ -8258,12 +8608,14 @@ data kappa_const_t_ice / gsw_result_ice( &
   1.1568438463977e-10_r8, 1.1549313434359e-10_r8, 1.1500777406276e-10_r8, &
   1.1532792876708e-10_r8, 1.1508546265635e-10_r8, 1.1484895715875e-10_r8, &
   1.1448688061695e-10_r8, 1.139655741648e-10_r8, 1.1377748424099e-10_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: internal_energy_ice
 
-data internal_energy_ice / gsw_result_ice( &
-  "internal_energy_ice", 1.2601e-06_r8, (/ &
+data internal_energy_ice%variable_name, &
+     internal_energy_ice%computation_accuracy, &
+     internal_energy_ice%values / &
+  "internal_energy_ice", 1.2601e-06_r8, &
   -338485.52543942_r8, -338100.62787003_r8, -338598.56136929_r8, &
   -340356.22331632_r8, -339577.81816009_r8, -344790.59192119_r8, &
   -340864.17320025_r8, -338926.69841841_r8, -344957.12322566_r8, &
@@ -8300,12 +8652,14 @@ data internal_energy_ice / gsw_result_ice( &
   -344866.07428584_r8, -345220.94187662_r8, -348965.41693898_r8, &
   -343425.79898675_r8, -344376.16037796_r8, -345251.65307171_r8, &
   -347576.15140857_r8, -351704.38041466_r8, -352023.26994042_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: enthalpy_ice
 
-data enthalpy_ice / gsw_result_ice( &
-  "enthalpy_ice", 1.2496e-06_r8, (/ &
+data enthalpy_ice%variable_name, &
+     enthalpy_ice%computation_accuracy, &
+     enthalpy_ice%values / &
+  "enthalpy_ice", 1.2496e-06_r8, &
   -338375.03800056_r8, -337881.09385671_r8, -338269.99899325_r8, &
   -339918.68541248_r8, -339031.23066026_r8, -344135.24417127_r8, &
   -339925.21342146_r8, -337715.06046462_r8, -343473.64401516_r8, &
@@ -8342,12 +8696,14 @@ data enthalpy_ice / gsw_result_ice( &
   -325492.37374662_r8, -323091.34556419_r8, -324087.93984739_r8, &
   -315773.54285918_r8, -313963.1501006_r8, -312068.83082086_r8, &
   -311640.11415119_r8, -313011.95021426_r8, -310566.00923056_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: entropy_ice
 
-data entropy_ice / gsw_result_ice( &
-  "entropy_ice", 4.6493e-09_r8, (/ &
+data entropy_ice%variable_name, &
+     entropy_ice%computation_accuracy, &
+     entropy_ice%values / &
+  "entropy_ice", 4.6493e-09_r8, &
   -1239.2291908496_r8, -1237.808063629_r8, -1239.6467496457_r8, &
   -1246.1501708896_r8, -1243.2675532861_r8, -1262.6489366557_r8, &
   -1248.0335397995_r8, -1240.8595837801_r8, -1263.2714645842_r8, &
@@ -8384,12 +8740,14 @@ data entropy_ice / gsw_result_ice( &
   -1263.0035040656_r8, -1264.3518875086_r8, -1278.4241019998_r8, &
   -1257.7044387224_r8, -1261.279921878_r8, -1264.5846748477_r8, &
   -1273.3311124301_r8, -1288.9313663785_r8, -1290.1813039913_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: cp_ice
 
-data cp_ice / gsw_result_ice( &
-  "cp_ice", 4.457e-09_r8, (/ &
+data cp_ice%variable_name, &
+     cp_ice%computation_accuracy, &
+     cp_ice%values / &
+  "cp_ice", 4.457e-09_r8, &
   2078.9899137873_r8, 2080.3550250568_r8, 2078.5921482_r8, &
   2072.3549584602_r8, 2075.1212480904_r8, 2056.5437052233_r8, &
   2070.5550518896_r8, 2077.4400237469_r8, 2055.9565205783_r8, &
@@ -8426,12 +8784,14 @@ data cp_ice / gsw_result_ice( &
   2056.4021599901_r8, 2055.1356384206_r8, 2041.660746493_r8, &
   2061.5735385337_r8, 2058.1659609704_r8, 2055.0172991216_r8, &
   2046.6405877938_r8, 2031.6874624203_r8, 2030.5065656792_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: chem_potential_water_ice
 
-data chem_potential_water_ice / gsw_result_ice( &
-  "chem_potential_water_ice", 7.7579e-07_r8, (/ &
+data chem_potential_water_ice%variable_name, &
+     chem_potential_water_ice%computation_accuracy, &
+     chem_potential_water_ice%values / &
+  "chem_potential_water_ice", 7.7579e-07_r8, &
   -2856.1466436639_r8, -2515.0896636323_r8, -2699.8798430037_r8, &
   -3640.6634793403_r8, -3061.6084746122_r8, -6111.5727361786_r8, &
   -3432.1471607215_r8, -1990.003173102_r8, -5364.3051252554_r8, &
@@ -8468,12 +8828,14 @@ data chem_potential_water_ice / gsw_result_ice( &
   13047.723000914_r8, 15658.033958288_r8, 16156.887545832_r8, &
   22424.348314103_r8, 24677.665536837_r8, 26983.943192945_r8, &
   28374.33395978_r8, 28615.085332449_r8, 31251.718658662_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: helmholtz_energy_ice
 
-data helmholtz_energy_ice / gsw_result_ice( &
-  "Helmholtz_energy_ice", 7.7232e-07_r8, (/ &
+data helmholtz_energy_ice%variable_name, &
+     helmholtz_energy_ice%computation_accuracy, &
+     helmholtz_energy_ice%values / &
+  "Helmholtz_energy_ice", 7.7232e-07_r8, &
   -2966.63408252_r8, -2734.62367695_r8, -3028.44221905_r8, -4078.20138318_r8, &
   -3608.19597445_r8, -6766.9204861_r8, -4371.10693952_r8, -3201.64112689_r8, &
   -6847.78433575_r8, -7266.89671475_r8, -4591.36132081_r8, -3014.85232818_r8, &
@@ -8501,12 +8863,14 @@ data helmholtz_energy_ice / gsw_result_ice( &
   -8501.72768697_r8, -6959.15516584_r8, -7826.04409992_r8, -6325.97753831_r8, &
   -6471.56235414_r8, -8720.58954575_r8, -5227.90781346_r8, -5735.34474052_r8, &
   -6198.8790579_r8, -7561.7032976_r8, -10077.344868_r8, -10205.5420512_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: adiabatic_lapse_rate_ice
 
-data adiabatic_lapse_rate_ice / gsw_result_ice( &
-  "adiabatic_lapse_rate_ice", 5.247e-20_r8, (/ &
+data adiabatic_lapse_rate_ice%variable_name, &
+     adiabatic_lapse_rate_ice%computation_accuracy, &
+     adiabatic_lapse_rate_ice%values / &
+  "adiabatic_lapse_rate_ice", 5.247e-20_r8, &
   2.2532939131206e-08_r8, 2.2544603686578e-08_r8, 2.2523901152231e-08_r8, &
   2.2456726358678e-08_r8, 2.2483006691338e-08_r8, 2.2286509763096e-08_r8, &
   2.2426715129186e-08_r8, 2.2492048524301e-08_r8, 2.2261792956974e-08_r8, &
@@ -8543,12 +8907,14 @@ data adiabatic_lapse_rate_ice / gsw_result_ice( &
   2.1863834583552e-08_r8, 2.1788361013749e-08_r8, 2.1586247825881e-08_r8, &
   2.1729381567717e-08_r8, 2.1631577874055e-08_r8, 2.1536200947689e-08_r8, &
   2.1387407775522e-08_r8, 2.1170159186773e-08_r8, 2.1095251515047e-08_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pt0_from_t_ice
 
-data pt0_from_t_ice / gsw_result_ice( &
-  "pt0_from_t_ice", 6.0526e-10_r8, (/ &
+data pt0_from_t_ice%variable_name, &
+     pt0_from_t_ice%computation_accuracy, &
+     pt0_from_t_ice%values / &
+  "pt0_from_t_ice", 6.0526e-10_r8, &
   -2.40194642416_r8, -2.21686964922_r8, -2.45632512542_r8, -3.30320859054_r8, &
   -2.92784394715_r8, -5.45120600207_r8, -3.5484429277_r8, -2.6142700592_r8, &
   -5.5322397299_r8, -5.86929674065_r8, -3.74737597714_r8, -2.48653730851_r8, &
@@ -8576,12 +8942,14 @@ data pt0_from_t_ice / gsw_result_ice( &
   -7.10631781994_r8, -5.9152114289_r8, -6.6224930493_r8, -5.49735975135_r8, &
   -5.67287465251_r8, -7.50431811712_r8, -4.80754992701_r8, -5.27299932524_r8, &
   -5.70317536793_r8, -6.84154776201_r8, -8.87144183175_r8, -9.03405340779_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pt_from_t_ice
 
-data pt_from_t_ice / gsw_result_ice( &
-  "pt_from_t_ice", 6.0536e-10_r8, (/ &
+data pt_from_t_ice%variable_name, &
+     pt_from_t_ice%computation_accuracy, &
+     pt_from_t_ice%values / &
+  "pt_from_t_ice", 6.0536e-10_r8, &
   -2.40194642416_r8, -2.21686964922_r8, -2.45632512542_r8, -3.30320859054_r8, &
   -2.92784394715_r8, -5.45120600207_r8, -3.5484429277_r8, -2.6142700592_r8, &
   -5.5322397299_r8, -5.86929674065_r8, -3.74737597714_r8, -2.48653730851_r8, &
@@ -8609,12 +8977,14 @@ data pt_from_t_ice / gsw_result_ice( &
   -7.10631781994_r8, -5.9152114289_r8, -6.6224930493_r8, -5.49735975135_r8, &
   -5.67287465251_r8, -7.50431811712_r8, -4.80754992701_r8, -5.27299932524_r8, &
   -5.70317536793_r8, -6.84154776201_r8, -8.87144183175_r8, -9.03405340779_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: t_from_pt0_ice
 
-data t_from_pt0_ice / gsw_result_ice( &
-  "t_from_pt0_ice", 6.0023e-10_r8, (/ &
+data t_from_pt0_ice%variable_name, &
+     t_from_pt0_ice%computation_accuracy, &
+     t_from_pt0_ice%values / &
+  "t_from_pt0_ice", 6.0023e-10_r8, &
   -2.40194642416_r8, -2.21461506654_r8, -2.45181985622_r8, -3.29647047469_r8, &
   -2.91884879072_r8, -5.44005971336_r8, -3.53139158119_r8, -2.59154062237_r8, &
   -5.50417060482_r8, -5.83570234402_r8, -3.70793695923_r8, -2.44108369441_r8, &
@@ -8642,12 +9012,14 @@ data t_from_pt0_ice / gsw_result_ice( &
   -6.81709361827_r8, -5.60240635161_r8, -6.2883915056_r8, -5.10632818297_r8, &
   -5.22666088119_r8, -7.00606008133_r8, -4.24907164131_r8, -4.66018282032_r8, &
   -5.0360644467_r8, -6.1224807697_r8, -8.10327644438_r8, -8.21225300912_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pot_enthalpy_from_pt_ice
 
-data pot_enthalpy_from_pt_ice / gsw_result_ice( &
-  "pot_enthalpy_from_pt_ice", 1.2603e-06_r8, (/ &
+data pot_enthalpy_from_pt_ice%variable_name, &
+     pot_enthalpy_from_pt_ice%computation_accuracy, &
+     pot_enthalpy_from_pt_ice%values / &
+  "pot_enthalpy_from_pt_ice", 1.2603e-06_r8, &
   -338375.03800056_r8, -337990.13906349_r8, -338488.07987869_r8, &
   -340245.76099591_r8, -339467.3548735_r8, -344680.17936627_r8, &
   -340753.75111848_r8, -338816.29062666_r8, -344846.80411902_r8, &
@@ -8684,12 +9056,14 @@ data pot_enthalpy_from_pt_ice / gsw_result_ice( &
   -344775.08845198_r8, -345135.86850932_r8, -348886.97712483_r8, &
   -343354.95198125_r8, -344313.5737781_r8, -345198.13027078_r8, &
   -347532.35872672_r8, -351671.00390044_r8, -352001.23398293_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pt_from_pot_enthalpy_ice
 
-data pt_from_pot_enthalpy_ice / gsw_result_ice( &
-  "pt_from_pot_enthalpy_ice", 6.0536e-10_r8, (/ &
+data pt_from_pot_enthalpy_ice%variable_name, &
+     pt_from_pot_enthalpy_ice%computation_accuracy, &
+     pt_from_pot_enthalpy_ice%values / &
+  "pt_from_pot_enthalpy_ice", 6.0536e-10_r8, &
   -2.40194642416_r8, -2.21686964922_r8, -2.45632512542_r8, -3.30320859054_r8, &
   -2.92784394715_r8, -5.45120600207_r8, -3.5484429277_r8, -2.6142700592_r8, &
   -5.5322397299_r8, -5.86929674065_r8, -3.74737597714_r8, -2.48653730851_r8, &
@@ -8717,12 +9091,14 @@ data pt_from_pot_enthalpy_ice / gsw_result_ice( &
   -7.10631781994_r8, -5.9152114289_r8, -6.6224930493_r8, -5.49735975135_r8, &
   -5.67287465251_r8, -7.50431811712_r8, -4.80754992701_r8, -5.27299932524_r8, &
   -5.70317536793_r8, -6.84154776201_r8, -8.87144183175_r8, -9.03405340779_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pot_enthalpy_from_pt_ice_poly
 
-data pot_enthalpy_from_pt_ice_poly / gsw_result_ice( &
-  "pot_enthalpy_from_pt_ice_poly", 1.2605e-06_r8, (/ &
+data pot_enthalpy_from_pt_ice_poly%variable_name, &
+     pot_enthalpy_from_pt_ice_poly%computation_accuracy, &
+     pot_enthalpy_from_pt_ice_poly%values / &
+  "pot_enthalpy_from_pt_ice_poly", 1.2605e-06_r8, &
   -338375.03588375_r8, -337990.13783234_r8, -338488.07752548_r8, &
   -340245.75617159_r8, -339467.35088372_r8, -344680.17489189_r8, &
   -340753.74594004_r8, -338816.28764507_r8, -344846.79976204_r8, &
@@ -8759,12 +9135,14 @@ data pot_enthalpy_from_pt_ice_poly / gsw_result_ice( &
   -344775.08404395_r8, -345135.86436564_r8, -348886.97627438_r8, &
   -343354.94675758_r8, -344313.56906144_r8, -345198.12617453_r8, &
   -347532.35664461_r8, -351671.00529632_r8, -352001.23560227_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pt_from_pot_enthalpy_ice_poly
 
-data pt_from_pot_enthalpy_ice_poly / gsw_result_ice( &
-  "pt_from_pot_enthalpy_ice_poly", 6.0578e-10_r8, (/ &
+data pt_from_pot_enthalpy_ice_poly%variable_name, &
+     pt_from_pot_enthalpy_ice_poly%computation_accuracy, &
+     pt_from_pot_enthalpy_ice_poly%values / &
+  "pt_from_pot_enthalpy_ice_poly", 6.0578e-10_r8, &
   -2.40194642416_r8, -2.21686964922_r8, -2.45632512542_r8, -3.30320859054_r8, &
   -2.92784394715_r8, -5.45120600207_r8, -3.5484429277_r8, -2.6142700592_r8, &
   -5.5322397299_r8, -5.86929674065_r8, -3.74737597714_r8, -2.48653730851_r8, &
@@ -8792,12 +9170,14 @@ data pt_from_pot_enthalpy_ice_poly / gsw_result_ice( &
   -7.10631781994_r8, -5.9152114289_r8, -6.6224930493_r8, -5.49735975135_r8, &
   -5.67287465251_r8, -7.50431811712_r8, -4.80754992701_r8, -5.27299932524_r8, &
   -5.70317536793_r8, -6.84154776201_r8, -8.87144183175_r8, -9.03405340779_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: pressure_freezing_ct
 
-data pressure_freezing_ct / gsw_result_ice( &
-  "pressure_freezing_CT", 7.8061e-07_r8, (/ &
+data pressure_freezing_ct%variable_name, &
+     pressure_freezing_ct%computation_accuracy, &
+     pressure_freezing_ct%values / &
+  "pressure_freezing_CT", 7.8061e-07_r8, &
   1096.2576803_r8, 1070.15780265_r8, 1034.10979826_r8, 1016.50879419_r8, &
   9e90_r8, 9e90_r8, 437.916027373_r8, 755.449491706_r8, 881.374551326_r8, &
   954.261417834_r8, 887.895489475_r8, 600.592848315_r8, 9e90_r8, 9e90_r8, &
@@ -8816,12 +9196,14 @@ data pressure_freezing_ct / gsw_result_ice( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_sa_ct_ratio
 
-data melting_ice_sa_ct_ratio / gsw_result_ice( &
-  "melting_ice_SA_CT_ratio", 2.9516e-12_r8, (/ &
+data melting_ice_sa_ct_ratio%variable_name, &
+     melting_ice_sa_ct_ratio%computation_accuracy, &
+     melting_ice_sa_ct_ratio%values / &
+  "melting_ice_SA_CT_ratio", 2.9516e-12_r8, &
   0.33168549572671_r8, 0.33771954459289_r8, 0.33752562735487_r8, &
   0.33680549826042_r8, 0.35861380642615_r8, 0.36438130865652_r8, &
   0.38251615461128_r8, 0.3908894615964_r8, 0.38731789147645_r8, &
@@ -8858,12 +9240,14 @@ data melting_ice_sa_ct_ratio / gsw_result_ice( &
   0.41071033691799_r8, 0.41093576995677_r8, 0.40692463116963_r8, &
   0.41396910274313_r8, 0.41313141666861_r8, 0.41240125815685_r8, &
   0.40993676584045_r8, 0.40536542049367_r8, 0.40531920773799_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_sa_ct_ratio_poly
 
-data melting_ice_sa_ct_ratio_poly / gsw_result_ice( &
-  "melting_ice_SA_CT_ratio_poly", 2.9517e-12_r8, (/ &
+data melting_ice_sa_ct_ratio_poly%variable_name, &
+     melting_ice_sa_ct_ratio_poly%computation_accuracy, &
+     melting_ice_sa_ct_ratio_poly%values / &
+  "melting_ice_SA_CT_ratio_poly", 2.9517e-12_r8, &
   0.33168549572671_r8, 0.33771954422683_r8, 0.33752562660978_r8, &
   0.33680549713831_r8, 0.35861380423964_r8, 0.36438130559991_r8, &
   0.38251615129452_r8, 0.39088945807584_r8, 0.3873178877609_r8, &
@@ -8900,12 +9284,14 @@ data melting_ice_sa_ct_ratio_poly / gsw_result_ice( &
   0.41071027632691_r8, 0.41093570125641_r8, 0.40692455313962_r8, &
   0.41396901093423_r8, 0.41313131127007_r8, 0.41240113820642_r8, &
   0.40993663120213_r8, 0.40536527150044_r8, 0.40531904237398_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_equilibrium_sa_ct_ratio
 
-data melting_ice_equilibrium_sa_ct_ratio / gsw_result_ice( &
-  "melting_ice_equilibrium_SA_CT_ratio", 1.6376e-12_r8, (/ &
+data melting_ice_equilibrium_sa_ct_ratio%variable_name, &
+     melting_ice_equilibrium_sa_ct_ratio%computation_accuracy, &
+     melting_ice_equilibrium_sa_ct_ratio%values / &
+  "melting_ice_equilibrium_SA_CT_ratio", 1.6376e-12_r8, &
   0.33414334412702_r8, 0.33986838553319_r8, 0.34030594345545_r8, &
   0.3414284479325_r8, 0.36618238158968_r8, 0.38026225193919_r8, &
   0.38998972217873_r8, 0.39502432853306_r8, 0.3980275064054_r8, &
@@ -8942,12 +9328,14 @@ data melting_ice_equilibrium_sa_ct_ratio / gsw_result_ice( &
   0.42975425996488_r8, 0.43064426260056_r8, 0.43149243568032_r8, &
   0.43232396924991_r8, 0.43314863421959_r8, 0.43395810257978_r8, &
   0.4347868367356_r8, 0.4356215064151_r8, 0.43646972355485_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_equilibrium_sa_ct_ratio_poly
 
-data melting_ice_equilibrium_sa_ct_ratio_poly / gsw_result_ice( &
-  "melting_ice_equilibrium_SA_CT_ratio_poly", 1.6377e-12_r8, (/ &
+data melting_ice_equilibrium_sa_ct_ratio_poly%variable_name, &
+     melting_ice_equilibrium_sa_ct_ratio_poly%computation_accuracy, &
+     melting_ice_equilibrium_sa_ct_ratio_poly%values / &
+  "melting_ice_equilibrium_SA_CT_ratio_poly", 1.6377e-12_r8, &
   0.33414329019901_r8, 0.33986833703748_r8, 0.34030590325666_r8, &
   0.34142841561703_r8, 0.36618234802077_r8, 0.38026222358012_r8, &
   0.38998971464819_r8, 0.39502434147261_r8, 0.39802753953618_r8, &
@@ -8984,12 +9372,14 @@ data melting_ice_equilibrium_sa_ct_ratio_poly / gsw_result_ice( &
   0.42975479407749_r8, 0.43064479066062_r8, 0.43149295254953_r8, &
   0.43232447513727_r8, 0.43314913463365_r8, 0.43395860801411_r8, &
   0.43478736298117_r8, 0.43562207421379_r8, 0.4364703586858_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_into_seawater_sa_final
 
-data melting_ice_into_seawater_sa_final / gsw_result_ice( &
-  "melting_ice_into_seawater_SA_final", 3.6441e-10_r8, (/ &
+data melting_ice_into_seawater_sa_final%variable_name, &
+     melting_ice_into_seawater_sa_final%computation_accuracy, &
+     melting_ice_into_seawater_sa_final%values / &
+  "melting_ice_into_seawater_SA_final", 3.6441e-10_r8, &
   27.614593517892_r8, 28.068255102176_r8, 28.095599027261_r8, &
   28.185691875733_r8, 29.885738875836_r8, 30.803040903732_r8, &
   31.954085286935_r8, 32.412350816674_r8, 32.713166969798_r8, &
@@ -9026,12 +9416,14 @@ data melting_ice_into_seawater_sa_final / gsw_result_ice( &
   33.914419302866_r8, 33.857178609065_r8, 33.79626372226_r8, &
   33.689672074486_r8, 33.603301666135_r8, 33.516564492698_r8, &
   33.436500401445_r8, 33.367328293786_r8, 33.273365486828_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_ice_into_seawater_ct_final
 
-data melting_ice_into_seawater_ct_final / gsw_result_ice( &
-  "melting_ice_into_seawater_CT_final", 6.0576e-10_r8, (/ &
+data melting_ice_into_seawater_ct_final%variable_name, &
+     melting_ice_into_seawater_ct_final%computation_accuracy, &
+     melting_ice_into_seawater_ct_final%values / &
+  "melting_ice_into_seawater_CT_final", 6.0576e-10_r8, &
   -1.41093471265_r8, -1.45647956398_r8, -1.45017799343_r8, -1.44272895296_r8, &
   -1.59486646519_r8, -1.70267455304_r8, -1.70850050254_r8, -1.83425824545_r8, &
   -1.79773202937_r8, -1.84824280761_r8, -1.84644529844_r8, -1.96019808883_r8, &
@@ -9059,12 +9451,14 @@ data melting_ice_into_seawater_ct_final / gsw_result_ice( &
   -2.88566200644_r8, -2.96770758118_r8, -3.05008080349_r8, -3.25700506621_r8, &
   -3.46586716836_r8, -3.67684998285_r8, -3.88831812192_r8, -4.10330292846_r8, &
   -4.32145341296_r8, -4.54142769721_r8, -4.76522432974_r8, -4.98984452431_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: ice_fraction_to_freeze_seawater_sa_freeze
 
-data ice_fraction_to_freeze_seawater_sa_freeze / gsw_result_ice( &
-  "ice_fraction_to_freeze_seawater_SA_freeze", 3.638e-10_r8, (/ &
+data ice_fraction_to_freeze_seawater_sa_freeze%variable_name, &
+     ice_fraction_to_freeze_seawater_sa_freeze%computation_accuracy, &
+     ice_fraction_to_freeze_seawater_sa_freeze%values / &
+  "ice_fraction_to_freeze_seawater_SA_freeze", 3.638e-10_r8, &
   27.623573185756_r8, 28.081447302697_r8, 28.103654114307_r8, &
   28.187063599892_r8, 29.90364103373_r8, 30.837290619367_r8, &
   31.961184743507_r8, 32.45029786444_r8, 32.723169623335_r8, &
@@ -9101,12 +9495,14 @@ data ice_fraction_to_freeze_seawater_sa_freeze / gsw_result_ice( &
   33.952421284689_r8, 33.894878041591_r8, 33.833431862073_r8, &
   33.7283452129_r8, 33.641628663235_r8, 33.554345344699_r8, &
   33.474348681112_r8, 33.40198259909_r8, 33.310797408192_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: ice_fraction_to_freeze_seawater_ct_freeze
 
-data ice_fraction_to_freeze_seawater_ct_freeze / gsw_result_ice( &
-  "ice_fraction_to_freeze_seawater_CT_freeze", 3.3783e-11_r8, (/ &
+data ice_fraction_to_freeze_seawater_ct_freeze%variable_name, &
+     ice_fraction_to_freeze_seawater_ct_freeze%computation_accuracy, &
+     ice_fraction_to_freeze_seawater_ct_freeze%values / &
+  "ice_fraction_to_freeze_seawater_CT_freeze", 3.3783e-11_r8, &
   -1.4836625652296_r8, -1.5171697900132_r8, -1.5260414554195_r8, &
   -1.5383844861429_r8, -1.6436140963126_r8, -1.7046365705155_r8, &
   -1.789083655638_r8, -1.8364479337119_r8, -1.8714067827215_r8, &
@@ -9143,12 +9539,14 @@ data ice_fraction_to_freeze_seawater_ct_freeze / gsw_result_ice( &
   -3.2592412765773_r8, -3.4680881553499_r8, -3.6790418402018_r8, &
   -3.8906002619339_r8, -4.1055659804147_r8, -4.3236851989152_r8, &
   -4.5436641584868_r8, -4.7672724490261_r8, -4.9920567217524_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: ice_fraction_to_freeze_seawater_w_ih
 
-data ice_fraction_to_freeze_seawater_w_ih / gsw_result_ice( &
-  "ice_fraction_to_freeze_seawater_w_Ih", 7.0421e-12_r8, (/ &
+data ice_fraction_to_freeze_seawater_w_ih%variable_name, &
+     ice_fraction_to_freeze_seawater_w_ih%computation_accuracy, &
+     ice_fraction_to_freeze_seawater_w_ih%values / &
+  "ice_fraction_to_freeze_seawater_w_Ih", 7.0421e-12_r8, &
   0.00166855877594_r8, 0.0020030321173_r8, 0.00242845831891_r8, &
   0.00266888879646_r8, 0.0127290315875_r8, 0.0191615461061_r8, &
   0.00835092384763_r8, 0.00572139096865_r8, 0.00469528575818_r8, &
@@ -9185,12 +9583,14 @@ data ice_fraction_to_freeze_seawater_w_ih / gsw_result_ice( &
   0.0327100414034_r8, 0.0346703973265_r8, 0.0366162791779_r8, &
   0.0397289408318_r8, 0.0422713764524_r8, 0.0447583421255_r8, &
   0.0470553077127_r8, 0.0491096180216_r8, 0.0516976204519_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dsa_dct_frazil
 
-data dsa_dct_frazil / gsw_result_ice( &
-  "dSA_dCT_frazil", 1.6976e-12_r8, (/ &
+data dsa_dct_frazil%variable_name, &
+     dsa_dct_frazil%computation_accuracy, &
+     dsa_dct_frazil%values / &
+  "dSA_dCT_frazil", 1.6976e-12_r8, &
   0.33459111646994_r8, 0.34043318315061_r8, 0.34092692826698_r8, &
   0.34205198351191_r8, 0.36949047578447_r8, 0.38578782051496_r8, &
   0.39224121311839_r8, 0.39688053760759_r8, 0.39936089295767_r8, &
@@ -9227,12 +9627,14 @@ data dsa_dct_frazil / gsw_result_ice( &
   0.43995260758833_r8, 0.44160033100708_r8, 0.44267605165332_r8, &
   0.44424942583703_r8, 0.4460693995696_r8, 0.44812668936002_r8, &
   0.44870967634161_r8, 0.45109927868808_r8, 0.45152857035841_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dsa_dp_frazil
 
-data dsa_dp_frazil / gsw_result_ice( &
-  "dSA_dP_frazil", 1.4507e-19_r8, (/ &
+data dsa_dp_frazil%variable_name, &
+     dsa_dp_frazil%computation_accuracy, &
+     dsa_dp_frazil%values / &
+  "dSA_dP_frazil", 1.4507e-19_r8, &
   -2.4975389078882e-08_r8, -2.5425456233617e-08_r8, -2.5475393934859e-08_r8, &
   -2.5572750347456e-08_r8, -2.7637514659792e-08_r8, -2.886862166101e-08_r8, &
   -2.9395606619289e-08_r8, -2.9781121126576e-08_r8, -3.0005377359089e-08_r8, &
@@ -9269,12 +9671,14 @@ data dsa_dp_frazil / gsw_result_ice( &
   -3.5647292459274e-08_r8, -3.6173049938889e-08_r8, -3.6652756669472e-08_r8, &
   -3.7173752863471e-08_r8, -3.7715106419719e-08_r8, -3.8278215907974e-08_r8, &
   -3.8716790617798e-08_r8, -3.930867389774e-08_r8, -3.9734034883564e-08_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dct_dp_frazil
 
-data dct_dp_frazil / gsw_result_ice( &
-  "dCT_dP_frazil", 8.8383e-20_r8, (/ &
+data dct_dp_frazil%variable_name, &
+     dct_dp_frazil%computation_accuracy, &
+     dct_dp_frazil%values / &
+  "dCT_dP_frazil", 8.8383e-20_r8, &
   -7.4644507428595e-08_r8, -7.46855990897e-08_r8, -7.4723912435891e-08_r8, &
   -7.4762759990151e-08_r8, -7.4798990694184e-08_r8, -7.4830308594178e-08_r8, &
   -7.4942677200055e-08_r8, -7.5037998351085e-08_r8, -7.5133489252963e-08_r8, &
@@ -9311,12 +9715,14 @@ data dct_dp_frazil / gsw_result_ice( &
   -8.1025301008398e-08_r8, -8.1913548063689e-08_r8, -8.279814670927e-08_r8, &
   -8.3677661019889e-08_r8, -8.4549862546298e-08_r8, -8.5418290891445e-08_r8, &
   -8.6284724085875e-08_r8, -8.713974008573e-08_r8, -8.799893847697e-08_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dsa_dct_frazil_poly
 
-data dsa_dct_frazil_poly / gsw_result_ice( &
-  "dSA_dCT_frazil_poly", 1.6977e-12_r8, (/ &
+data dsa_dct_frazil_poly%variable_name, &
+     dsa_dct_frazil_poly%computation_accuracy, &
+     dsa_dct_frazil_poly%values / &
+  "dSA_dCT_frazil_poly", 1.6977e-12_r8, &
   0.33459101869473_r8, 0.34043308373712_r8, 0.34092683275722_r8, &
   0.34205189686973_r8, 0.36949027117826_r8, 0.38578763143698_r8, &
   0.39224117599942_r8, 0.39688054070922_r8, 0.39936092460662_r8, &
@@ -9353,12 +9759,14 @@ data dsa_dct_frazil_poly / gsw_result_ice( &
   0.43995265362162_r8, 0.44160026860286_r8, 0.44267592554796_r8, &
   0.44424923097801_r8, 0.4460691528311_r8, 0.44812641746992_r8, &
   0.44870950486772_r8, 0.45109916807441_r8, 0.45152865929133_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dsa_dp_frazil_poly
 
-data dsa_dp_frazil_poly / gsw_result_ice( &
-  "dSA_dP_frazil_poly", 1.4507e-19_r8, (/ &
+data dsa_dp_frazil_poly%variable_name, &
+     dsa_dp_frazil_poly%computation_accuracy, &
+     dsa_dp_frazil_poly%values / &
+  "dSA_dP_frazil_poly", 1.4507e-19_r8, &
   -2.4990378528585e-08_r8, -2.5440434269897e-08_r8, -2.5490219461352e-08_r8, &
   -2.558743810527e-08_r8, -2.7652571913228e-08_r8, -2.8883713565401e-08_r8, &
   -2.9410165950428e-08_r8, -2.9795240008683e-08_r8, -3.0019051704916e-08_r8, &
@@ -9395,12 +9803,14 @@ data dsa_dp_frazil_poly / gsw_result_ice( &
   -3.5644196343586e-08_r8, -3.6168999686957e-08_r8, -3.6648091010328e-08_r8, &
   -3.7168761555434e-08_r8, -3.7710052297117e-08_r8, -3.8273331943447e-08_r8, &
   -3.8712302173085e-08_r8, -3.9304733294069e-08_r8, -3.9730810052296e-08_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: dct_dp_frazil_poly
 
-data dct_dp_frazil_poly / gsw_result_ice( &
-  "dCT_dP_frazil_poly", 8.7258e-20_r8, (/ &
+data dct_dp_frazil_poly%variable_name, &
+     dct_dp_frazil_poly%computation_accuracy, &
+     dct_dp_frazil_poly%values / &
+  "dCT_dP_frazil_poly", 8.7258e-20_r8, &
   -7.4689328560207e-08_r8, -7.4729617905005e-08_r8, -7.4767419317518e-08_r8, &
   -7.4805719071966e-08_r8, -7.4839783534886e-08_r8, -7.4869464989882e-08_r8, &
   -7.4979802606119e-08_r8, -7.5073572404027e-08_r8, -7.5167723869043e-08_r8, &
@@ -9437,12 +9847,14 @@ data dct_dp_frazil_poly / gsw_result_ice( &
   -8.1018255146705e-08_r8, -8.1904387878633e-08_r8, -8.2787630623833e-08_r8, &
   -8.3666462345039e-08_r8, -8.4538578957499e-08_r8, -8.5407444085834e-08_r8, &
   -8.6274754051615e-08_r8, -8.7131025893591e-08_r8, -8.7991779114648e-08_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_sa_final
 
-data frazil_properties_potential_sa_final / gsw_result_ice( &
-  "frazil_properties_potential_SA_final", 3.6572e-10_r8, (/ &
+data frazil_properties_potential_sa_final%variable_name, &
+     frazil_properties_potential_sa_final%computation_accuracy, &
+     frazil_properties_potential_sa_final%values / &
+  "frazil_properties_potential_SA_final", 3.6572e-10_r8, &
   27.61945299247_r8, 28.077387196801_r8, 28.099512156485_r8, &
   28.185691875733_r8, 29.898278492069_r8, 30.833134150415_r8, &
   31.958028921858_r8, 32.447867444435_r8, 32.721254612213_r8, &
@@ -9479,12 +9891,14 @@ data frazil_properties_potential_sa_final / gsw_result_ice( &
   33.922012277638_r8, 33.85611600569_r8, 33.790358788593_r8, &
   33.674376716374_r8, 33.574946173078_r8, 33.470720008763_r8, &
   33.412220981719_r8, 33.296687379164_r8, 33.270299588068_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_ct_final
 
-data frazil_properties_potential_ct_final / gsw_result_ice( &
-  "frazil_properties_potential_CT_final", 6.104e-10_r8, (/ &
+data frazil_properties_potential_ct_final%variable_name, &
+     frazil_properties_potential_ct_final%computation_accuracy, &
+     frazil_properties_potential_ct_final%values / &
+  "frazil_properties_potential_CT_final", 6.104e-10_r8, &
   -1.48342974905_r8, -1.51693991538_r8, -1.52580689883_r8, -1.52990473633_r8, &
   -1.64330810094_r8, -1.70439844956_r8, -1.78890196017_r8, -1.83630767882_r8, &
   -1.87129611568_r8, -1.90491887605_r8, -1.93967981426_r8, -1.97897598197_r8, &
@@ -9512,12 +9926,14 @@ data frazil_properties_potential_ct_final / gsw_result_ice( &
   -2.88689535327_r8, -2.96852325934_r8, -3.05084881655_r8, -3.25745184482_r8, &
   -3.4658045719_r8, -3.67650178925_r8, -3.88741561913_r8, -4.10162885848_r8, &
   -4.31874570187_r8, -4.48443651344_r8, -4.76105010931_r8, -4.82557926698_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_w_ih_final
 
-data frazil_properties_potential_w_ih_final / gsw_result_ice( &
-  "frazil_properties_potential_w_Ih_final", 7.1653e-12_r8, (/ &
+data frazil_properties_potential_w_ih_final%variable_name, &
+     frazil_properties_potential_w_ih_final%computation_accuracy, &
+     frazil_properties_potential_w_ih_final%values / &
+  "frazil_properties_potential_w_Ih_final", 7.1653e-12_r8, &
   0.000175943910977_r8, 0.000325247308841_r8, 0.000139259685443_r8, 0._r8, &
   0.000419409306027_r8, 0.002017432853_r8, 0.000123400442883_r8, &
   0.00120454864895_r8, 0.000247167858043_r8, 0.000461262093306_r8, &
@@ -9549,12 +9965,14 @@ data frazil_properties_potential_w_ih_final / gsw_result_ice( &
   0.00355555619926_r8, 0.00281035898774_r8, 0.00212658964777_r8, &
   0.00260870991664_r8, 0.00137727293636_r8, 0.000533324448916_r8, &
   0.00110991724646_r8, 0.00249479651339_r8, 0._r8, 0.00211731119253_r8, 0._r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_poly_sa_final
 
-data frazil_properties_potential_poly_sa_final / gsw_result_ice( &
-  "frazil_properties_potential_poly_SA_final", 3.6578e-10_r8, (/ &
+data frazil_properties_potential_poly_sa_final%variable_name, &
+     frazil_properties_potential_poly_sa_final%computation_accuracy, &
+     frazil_properties_potential_poly_sa_final%values / &
+  "frazil_properties_potential_poly_SA_final", 3.6578e-10_r8, &
   27.619462009144_r8, 28.077395240092_r8, 28.099518740265_r8, 9e90_r8, &
   29.898283690558_r8, 30.833138422429_r8, 31.958029861582_r8, &
   32.447864928944_r8, 32.721248702259_r8, 32.97016250481_r8, &
@@ -9587,12 +10005,14 @@ data frazil_properties_potential_poly_sa_final / gsw_result_ice( &
   33.921947620388_r8, 33.856059908809_r8, 33.790313145771_r8, &
   33.674342511332_r8, 33.574923909669_r8, 33.470709584706_r8, 9e90_r8, &
   33.296698299423_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_poly_ct_final
 
-data frazil_properties_potential_poly_ct_final / gsw_result_ice( &
-  "frazil_properties_potential_poly_CT_final", 3.3237e-11_r8, (/ &
+data frazil_properties_potential_poly_ct_final%variable_name, &
+     frazil_properties_potential_poly_ct_final%computation_accuracy, &
+     frazil_properties_potential_poly_ct_final%values / &
+  "frazil_properties_potential_poly_CT_final", 3.3237e-11_r8, &
   -1.4834027127773_r8, -1.5169161924119_r8, -1.5257874983377_r8, 9e90_r8, &
   -1.6432937054344_r8, -1.7043869362712_r8, -1.7888995253979_r8, &
   -1.8363140441232_r8, -1.8713110314647_r8, -1.9049419808812_r8, &
@@ -9625,12 +10045,14 @@ data frazil_properties_potential_poly_ct_final / gsw_result_ice( &
   -3.2576083532515_r8, -3.4659405236976_r8, -3.6766125464238_r8, &
   -3.88749883286_r8, -4.1016831600569_r8, -4.3187712737818_r8, 9e90_r8, &
   -4.7610234582053_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_potential_poly_w_ih_final
 
-data frazil_properties_potential_poly_w_ih_final / gsw_result_ice( &
-  "frazil_properties_potential_poly_w_Ih_final", 7.1663e-12_r8, (/ &
+data frazil_properties_potential_poly_w_ih_final%variable_name, &
+     frazil_properties_potential_poly_w_ih_final%computation_accuracy, &
+     frazil_properties_potential_poly_w_ih_final%values / &
+  "frazil_properties_potential_poly_w_Ih_final", 7.1663e-12_r8, &
   0.000176270314407_r8, 0.000325533684252_r8, 0.000139493955038_r8, 9e90_r8, &
   0.000419583105568_r8, 0.00201757112615_r8, 0.000123429844205_r8, &
   0.00120447121825_r8, 0.000246987287503_r8, 0.000460982348892_r8, &
@@ -9663,12 +10085,14 @@ data frazil_properties_potential_poly_w_ih_final / gsw_result_ice( &
   0.0021246876417_r8, 0.00260705731618_r8, 0.00137592403026_r8, &
   0.000532309230885_r8, 0.0011092548861_r8, 0.0024944858522_r8, 9e90_r8, &
   0.00211763846635_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_sa_final
 
-data frazil_properties_sa_final / gsw_result_ice( &
-  "frazil_properties_SA_final", 3.6609e-10_r8, (/ &
+data frazil_properties_sa_final%variable_name, &
+     frazil_properties_sa_final%computation_accuracy, &
+     frazil_properties_sa_final%values / &
+  "frazil_properties_SA_final", 3.6609e-10_r8, &
   27.623623561427_r8, 28.081503352371_r8, 28.103699698138_r8, &
   28.187078397573_r8, 29.903781057656_r8, 30.838813040454_r8, &
   31.961260688773_r8, 32.45049028041_r8, 32.723392388456_r8, &
@@ -9705,12 +10129,14 @@ data frazil_properties_sa_final / gsw_result_ice( &
   33.953616215346_r8, 33.896296968559_r8, 33.835302383735_r8, &
   33.728530715664_r8, 33.642029190536_r8, 33.555164066308_r8, &
   33.47498991009_r8, 33.405732116443_r8, 33.311631801947_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_ct_final
 
-data frazil_properties_ct_final / gsw_result_ice( &
-  "frazil_properties_CT_final", 3.3901e-11_r8, (/ &
+data frazil_properties_ct_final%variable_name, &
+     frazil_properties_ct_final%computation_accuracy, &
+     frazil_properties_ct_final%values / &
+  "frazil_properties_CT_final", 3.3901e-11_r8, &
   -1.4836654117882_r8, -1.5171729634541_r8, -1.5260440368264_r8, &
   -1.5383853245131_r8, -1.6436220863971_r8, -1.704723789896_r8, &
   -1.7890880281931_r8, -1.836459037731_r8, -1.8714196562076_r8, &
@@ -9747,12 +10173,14 @@ data frazil_properties_ct_final / gsw_result_ice( &
   -3.2593115971857_r8, -3.4681717549482_r8, -3.679152155709_r8, &
   -3.8906112094329_r8, -4.1055896315956_r8, -4.3237335657105_r8, &
   -4.5437020513942_r8, -4.7674940656_r8, -4.9921060369551_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: frazil_properties_w_ih_final
 
-data frazil_properties_w_ih_final / gsw_result_ice( &
-  "frazil_properties_w_Ih_final", 7.0921e-12_r8, (/ &
+data frazil_properties_w_ih_final%variable_name, &
+     frazil_properties_w_ih_final%computation_accuracy, &
+     frazil_properties_w_ih_final%values / &
+  "frazil_properties_w_Ih_final", 7.0921e-12_r8, &
   0.000326895691821_r8, 0.000471778523702_r8, 0.000288242151903_r8, &
   4.91899805953e-05_r8, 0.000603341155626_r8, 0.00220120883855_r8, &
   0.000224503091641_r8, 0.00128527706379_r8, 0.000312480397419_r8, &
@@ -9789,12 +10217,14 @@ data frazil_properties_w_ih_final / gsw_result_ice( &
   0.00305540762409_r8, 0.00379102615695_r8, 0.00270374831512_r8, &
   0.00213805244893_r8, 0.00310172815894_r8, 0.00500509229493_r8, &
   0.0018750992469_r8, 0.00537465203624_r8, 0.0012407742174_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_sa_ct_ratio
 
-data melting_seaice_sa_ct_ratio / gsw_result_ice( &
-  "melting_seaice_SA_CT_ratio", 3.6147e-11_r8, (/ &
+data melting_seaice_sa_ct_ratio%variable_name, &
+     melting_seaice_sa_ct_ratio%computation_accuracy, &
+     melting_seaice_sa_ct_ratio%values / &
+  "melting_seaice_SA_CT_ratio", 3.6147e-11_r8, &
   0.29520427930467_r8, 0.30391484541865_r8, 0.31529758880791_r8, &
   0.33148841493996_r8, 0.34640517850802_r8, 0.28560011901917_r8, &
   0.3734463993028_r8, 0.35560260360796_r8, 0.34337438382702_r8, &
@@ -9831,12 +10261,14 @@ data melting_seaice_sa_ct_ratio / gsw_result_ice( &
   0.37642259432303_r8, 0.37245281640892_r8, 0.36148571284822_r8, &
   0.40935645292888_r8, 0.4038359241186_r8, 0.39458225686148_r8, &
   0.39706605708896_r8, 0.33792875644904_r8, 0.39099525620137_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_sa_ct_ratio_poly
 
-data melting_seaice_sa_ct_ratio_poly / gsw_result_ice( &
-  "melting_seaice_SA_CT_ratio_poly", 3.6145e-11_r8, (/ &
+data melting_seaice_sa_ct_ratio_poly%variable_name, &
+     melting_seaice_sa_ct_ratio_poly%computation_accuracy, &
+     melting_seaice_sa_ct_ratio_poly%values / &
+  "melting_seaice_SA_CT_ratio_poly", 3.6145e-11_r8, &
   0.29520421795749_r8, 0.30391447349777_r8, 0.3152976431775_r8, &
   0.33148845968334_r8, 0.34640532367275_r8, 0.2856000291539_r8, &
   0.37344647093321_r8, 0.35560329960651_r8, 0.34337435390838_r8, &
@@ -9873,12 +10305,14 @@ data melting_seaice_sa_ct_ratio_poly / gsw_result_ice( &
   0.3764223039194_r8, 0.37245236102598_r8, 0.36148755439463_r8, &
   0.40935640856272_r8, 0.40383522539265_r8, 0.39458065149826_r8, &
   0.39706552414606_r8, 0.33793222636922_r8, 0.39099590196662_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_equilibrium_sa_ct_ratio
 
-data melting_seaice_equilibrium_sa_ct_ratio / gsw_result_ice( &
-  "melting_seaice_equilibrium_SA_CT_ratio", 1.6376e-12_r8, (/ &
+data melting_seaice_equilibrium_sa_ct_ratio%variable_name, &
+     melting_seaice_equilibrium_sa_ct_ratio%computation_accuracy, &
+     melting_seaice_equilibrium_sa_ct_ratio%values / &
+  "melting_seaice_equilibrium_SA_CT_ratio", 1.6376e-12_r8, &
   0.33414334412702_r8, 0.33986838553319_r8, 0.34030594345545_r8, &
   0.3414284479325_r8, 0.36618238158968_r8, 0.38026225193919_r8, &
   0.38998972217873_r8, 0.39502432853306_r8, 0.3980275064054_r8, &
@@ -9915,12 +10349,14 @@ data melting_seaice_equilibrium_sa_ct_ratio / gsw_result_ice( &
   0.42975425996488_r8, 0.43064426260056_r8, 0.43149243568032_r8, &
   0.43232396924991_r8, 0.43314863421959_r8, 0.43395810257978_r8, &
   0.4347868367356_r8, 0.4356215064151_r8, 0.43646972355485_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_equilibrium_sa_ct_ratio_poly
 
-data melting_seaice_equilibrium_sa_ct_ratio_poly / gsw_result_ice( &
-  "melting_seaice_equilibrium_SA_CT_ratio_poly", 1.6377e-12_r8, (/ &
+data melting_seaice_equilibrium_sa_ct_ratio_poly%variable_name, &
+     melting_seaice_equilibrium_sa_ct_ratio_poly%computation_accuracy, &
+     melting_seaice_equilibrium_sa_ct_ratio_poly%values / &
+  "melting_seaice_equilibrium_SA_CT_ratio_poly", 1.6377e-12_r8, &
   0.33414329019901_r8, 0.33986833703748_r8, 0.34030590325666_r8, &
   0.34142841561703_r8, 0.36618234802077_r8, 0.38026222358012_r8, &
   0.38998971464819_r8, 0.39502434147261_r8, 0.39802753953618_r8, &
@@ -9957,12 +10393,14 @@ data melting_seaice_equilibrium_sa_ct_ratio_poly / gsw_result_ice( &
   0.42975479407749_r8, 0.43064479066062_r8, 0.43149295254953_r8, &
   0.43232447513727_r8, 0.43314913463365_r8, 0.43395860801411_r8, &
   0.43478736298117_r8, 0.43562207421379_r8, 0.4364703586858_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_into_seawater_sa_final
 
-data melting_seaice_into_seawater_sa_final / gsw_result_ice( &
-  "melting_seaice_into_seawater_SA_final", 9e90_r8, (/ &
+data melting_seaice_into_seawater_sa_final%variable_name, &
+     melting_seaice_into_seawater_sa_final%computation_accuracy, &
+     melting_seaice_into_seawater_sa_final%values / &
+  "melting_seaice_into_seawater_SA_final", 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
@@ -9977,12 +10415,14 @@ data melting_seaice_into_seawater_sa_final / gsw_result_ice( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: melting_seaice_into_seawater_ct_final
 
-data melting_seaice_into_seawater_ct_final / gsw_result_ice( &
-  "melting_seaice_into_seawater_CT_final", 9e90_r8, (/ &
+data melting_seaice_into_seawater_ct_final%variable_name, &
+     melting_seaice_into_seawater_ct_final%computation_accuracy, &
+     melting_seaice_into_seawater_ct_final%values / &
+  "melting_seaice_into_seawater_CT_final", 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
@@ -9997,12 +10437,14 @@ data melting_seaice_into_seawater_ct_final / gsw_result_ice( &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8, &
   9e90_r8, 9e90_r8, 9e90_r8, 9e90_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: seaice_fraction_to_freeze_seawater_sa_freeze
 
-data seaice_fraction_to_freeze_seawater_sa_freeze / gsw_result_ice( &
-  "seaice_fraction_to_freeze_seawater_SA_freeze", 4.3858e-10_r8, (/ &
+data seaice_fraction_to_freeze_seawater_sa_freeze%variable_name, &
+     seaice_fraction_to_freeze_seawater_sa_freeze%computation_accuracy, &
+     seaice_fraction_to_freeze_seawater_sa_freeze%values / &
+  "seaice_fraction_to_freeze_seawater_SA_freeze", 4.3858e-10_r8, &
   27.628567831265_r8, 28.086993426582_r8, 28.108080585916_r8, &
   28.188232438451_r8, 29.916512316887_r8, 30.965442620278_r8, &
   31.967432241299_r8, 32.466815536561_r8, 32.740342958196_r8, &
@@ -10039,12 +10481,14 @@ data seaice_fraction_to_freeze_seawater_sa_freeze / gsw_result_ice( &
   34.046193948537_r8, 34.006429893195_r8, 33.974025098384_r8, &
   33.743526698623_r8, 33.674258822846_r8, 33.620727694079_r8, &
   33.525053779096_r8, 33.683335870158_r8, 33.373521548156_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: seaice_fraction_to_freeze_seawater_ct_freeze
 
-data seaice_fraction_to_freeze_seawater_ct_freeze / gsw_result_ice( &
-  "seaice_fraction_to_freeze_seawater_CT_freeze", 3.7364e-11_r8, (/ &
+data seaice_fraction_to_freeze_seawater_ct_freeze%variable_name, &
+     seaice_fraction_to_freeze_seawater_ct_freeze%computation_accuracy, &
+     seaice_fraction_to_freeze_seawater_ct_freeze%values / &
+  "seaice_fraction_to_freeze_seawater_CT_freeze", 3.7364e-11_r8, &
   -1.483944798547_r8, -1.517483805989_r8, -1.5262921282243_r8, &
   -1.5384507074382_r8, -1.6443485803816_r8, -1.7119803227179_r8, &
   -1.7894433605082_r8, -1.837401174955_r8, -1.8723992566111_r8, &
@@ -10081,12 +10525,14 @@ data seaice_fraction_to_freeze_seawater_ct_freeze / gsw_result_ice( &
   -3.2647607206391_r8, -3.4746619136662_r8, -3.6873356356849_r8, &
   -3.8914962268889_r8, -4.1074929093166_r8, -4.3276072668164_r8, &
   -4.5466608004786_r8, -4.783909923726_r8, -4.9957642956297_r8 &
-  /) ) /
+  /
 
 type(gsw_result_ice) :: seaice_fraction_to_freeze_seawater_w_ih
 
-data seaice_fraction_to_freeze_seawater_w_ih / gsw_result_ice( &
-  "seaice_fraction_to_freeze_seawater_w_Ih", 1.1472e-11_r8, (/ &
+data seaice_fraction_to_freeze_seawater_w_ih%variable_name, &
+     seaice_fraction_to_freeze_seawater_w_ih%computation_accuracy, &
+     seaice_fraction_to_freeze_seawater_w_ih%values / &
+  "seaice_fraction_to_freeze_seawater_w_Ih", 1.1472e-11_r8, &
   0.00198165098038_r8, 0.00246001600695_r8, 0.00270372932439_r8, &
   0.00270784190064_r8, 0.013310303111_r8, 0.0212621836904_r8, &
   0.00856187144409_r8, 0.0069819318337_r8, 0.00499001722768_r8, &
@@ -10123,7 +10569,7 @@ data seaice_fraction_to_freeze_seawater_w_ih / gsw_result_ice( &
   0.0356217515117_r8, 0.0382796677036_r8, 0.0391586184315_r8, &
   0.0417670576392_r8, 0.0452205818466_r8, 0.049505477746_r8, &
   0.0488148325977_r8, 0.0541045099485_r8, 0.0528418448232_r8 &
-  /) ) /
+  /
 
 
 end module


### PR DESCRIPTION
versions of gfortran (10.4.0, 11.3.0 and 12.1.0) fails

For a discussion of the Fortran issue see:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106684

For a discussion on how it is resolved see:
https://github.com/TEOS-10/GSW-Fortran/issues/23